### PR TITLE
Fix #52 Install SciPy to CircleCI test environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install astropy pytest pytest-astropy "setuptools>=30.3"
+            pip install astropy pytest pytest-astropy scipy "setuptools>=30.3"
       - run:
           name: Run Tests
           command: |


### PR DESCRIPTION
## Description
Fix issue #52 by adding SciPy to the list of modules installed to the CircleCI virtual environment for running tests.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/develop/CONTRIBUTING.md)
- [x] Assign someone from the infrastructure team to review this pull request
