### PR TITLE
Galaxy ellipticity distribution from Kacprzak et al. 2109

### DIFF
--- a/docs/galaxy/index.rst
+++ b/docs/galaxy/index.rst
@@ -3,6 +3,7 @@ Galaxies (`skypy.galaxy`)
 *************************
 
 
+Morphology (`skypy.galaxy.morphology`)
 Redshifts (`skypy.galaxy.redshift`)
 ===================================
 
@@ -11,4 +12,5 @@ Reference/API
 =============
 
 .. automodapi:: skypy.galaxy
+.. automodapi:: skypy.galaxy.morphology
 .. automodapi:: skypy.galaxy.redshift

--- a/skypy/galaxy/morphology.py
+++ b/skypy/galaxy/morphology.py
@@ -9,41 +9,39 @@ from scipy.stats._continuous_distns import beta_gen
 
 def _kacprzak_parameterization(beta_method):
     def reparameterize(self, *args):
-        *beta_args, e_sum, e_ratio = args
+        *beta_args, e_ratio, e_sum = args
         a = e_sum * e_ratio
         b = e_sum * (1.0 - e_ratio)
         return beta_method(self, *beta_args, a, b)
     return reparameterize
 
 
-class ellipticity_beta_gen(beta_gen):
+class kacprzak_gen(beta_gen):
     r'''Galaxy ellipticities sampled from a reparameterized beta distribution.
 
     The ellipticities follow a beta distribution parameterized by
-    :math:`e_{\rm sum}` and :math:`e_{\rm ratio}` as presented in Kacprzak et
+    :math:`e_{\rm ratio}` and :math:`e_{\rm sum}` as presented in Kacprzak et
     al. 2019.
 
     Parameters
     ----------
-    e_sum : array_like
-        Parameter controlling the width of the distribution, must be positive.
     e_ratio : array_like
         Mean ellipticity of the distribution, must be between 0 and 1.
+    e_sum : array_like
+        Parameter controlling the width of the distribution, must be positive.
 
     Notes
     -----
-    The probability distribution function :math:`p(e)` for ellipticity :math:`e`
-    is given by a beta distribution:
+    The probability distribution function :math:`p(e)` for ellipticity
+    :math:`e` is given by a beta distribution:
 
     .. math::
 
-        p(e) \sim \frac{\Gamma(\alpha+\beta)}{\Gamma(\alpha) \Gamma(\beta)}
-                  x^{\alpha-1} (1-x)^{\beta-1}
+        p(e) \sim \frac{\Gamma(a+b)}{\Gamma(a) \Gamma(b)} x^{a-1} (1-x)^{b-1}
 
-    for :math:`0 <= e <= 1`, :math:`\alpha = e_{\rm sum} e_{\rm ratio}`,
-    :math:`\beta = e_{\rm sum} (1 - e_{\rm ratio})`, :math:`e_{\rm sum} > 0`
-    and :math:`0 < e_{\rm ratio} < 1`, where :math:`\Gamma` is the gamma
-    function.
+    for :math:`0 <= e <= 1`, :math:`a = e_{\rm sum} e_{\rm ratio}`,
+    :math:`b = e_{\rm sum} (1 - e_{\rm ratio})`, :math:`0 < e_{\rm ratio} < 1`
+    and :math:`e_{\rm sum} > 0`, where :math:`\Gamma` is the gamma function.
 
     References
     ----------
@@ -51,19 +49,19 @@ class ellipticity_beta_gen(beta_gen):
 
     Examples
     --------
-    >>> from skypy.galaxy.morphology import ellipticity_beta
+    >>> from skypy.galaxy.morphology import kacprzak
 
     Sample 10 random variates from the Kacprzak model with
-    :math:`e_{\rm sum} = 1.0` and :math:`e_{\rm ratio} = 0.5`:
+    :math:`e_{\rm ratio} = 0.5` and :math:`e_{\rm sum} = 1.0`:
 
-    >>> ellipticity = ellipticity_beta.rvs(1.0, 0.5, size=10)
+    >>> ellipticity = kacprzak.rvs(0.5, 1.0, size=10)
 
     Fix distribution parameters for repeated use:
 
-    >>> ellipticity_dist = ellipticity_beta(1.0, 0.5)
-    >>> ellipticity_dist.mean()
+    >>> kacprzak_distribution = kacprzak(0.5, 1.0)
+    >>> kacprzak_distribution.mean()
     0.5
-    >>> ellipticity = ellipticity_dist.rvs(size=10)
+    >>> ellipticity = kacprzak_distribution.rvs(size=10)
     '''
 
     @_kacprzak_parameterization
@@ -90,4 +88,4 @@ class ellipticity_beta_gen(beta_gen):
         return super(beta_gen, self).fit(data, *args, **kwds)
 
 
-ellipticity_beta = ellipticity_beta_gen(a=0.0, b=1.0, name='ellipticity_beta')
+kacprzak = kacprzak_gen(a=0.0, b=1.0, name='kacprzak')

--- a/skypy/galaxy/morphology.py
+++ b/skypy/galaxy/morphology.py
@@ -17,6 +17,54 @@ def _kacprzak_parameterization(beta_method):
 
 
 class ellipticity_beta_gen(beta_gen):
+    r'''Galaxy ellipticities sampled from a reparameterized beta distribution.
+
+    The ellipticities follow a beta distribution parameterized by
+    :math:`e_{\rm sum}` and :math:`e_{\rm ratio}` as presented in Kacprzak et
+    al. 2019.
+
+    Parameters
+    ----------
+    e_sum : array_like
+        Parameter controlling the width of the distribution, must be positive.
+    e_ratio : array_like
+        Mean ellipticity of the distribution, must be between 0 and 1.
+
+    Notes
+    -----
+    The probability distribution function :math:`p(e)` for ellipticity :math:`e`
+    is given by a beta distribution:
+
+    .. math::
+
+        p(e) \sim \frac{\Gamma(\alpha+\beta)}{\Gamma(\alpha) \Gamma(\beta)}
+                  x^{\alpha-1} (1-x)^{\beta-1}
+
+    for :math:`0 <= e <= 1`, :math:`\alpha = e_{\rm sum} e_{\rm ratio}`,
+    :math:`\beta = e_{\rm sum} (1 - e_{\rm ratio})`, :math:`e_{\rm sum} > 0`
+    and :math:`0 < e_{\rm ratio} < 1`, where :math:`\Gamma` is the gamma
+    function.
+
+    References
+    ----------
+    [1] Kacprzak T., Herbel J., Nicola A. et al., arXiv:1906.01018
+
+    Examples
+    --------
+    >>> from skypy.galaxy.morphology import ellipticity_beta
+
+    Sample 10 random variates from the Kacprzak model with
+    :math:`e_{\rm sum} = 1.0` and :math:`e_{\rm ratio} = 0.5`:
+
+    >>> ellipticity = ellipticity_beta.rvs(1.0, 0.5, size=10)
+
+    Fix distribution parameters for repeated use:
+
+    >>> ellipticity_dist = ellipticity_beta(1.0, 0.5)
+    >>> ellipticity_dist.mean()
+    0.5
+    >>> ellipticity = ellipticity_dist.rvs(size=10)
+    '''
 
     @_kacprzak_parameterization
     def _rvs(self, *args):

--- a/skypy/galaxy/morphology.py
+++ b/skypy/galaxy/morphology.py
@@ -89,4 +89,4 @@ class kacprzak_gen(stats._continuous_distns.beta_gen):
             data, *args, **kwds)
 
 
-kacprzak = kacprzak_gen(a=0.0, b=1.0, name='kacprzak')
+kacprzak = kacprzak_gen(a=0.0, b=1.0, name='kacprzak', shapes="e_ratio e_sum")

--- a/skypy/galaxy/morphology.py
+++ b/skypy/galaxy/morphology.py
@@ -4,7 +4,7 @@ This module provides facilities to sample the morphological properties of
 galaxies using a number of models.
 """
 
-from scipy.stats._continuous_distns import beta_gen
+from scipy import stats
 
 
 def _kacprzak_parameterization(beta_method):
@@ -16,7 +16,7 @@ def _kacprzak_parameterization(beta_method):
     return reparameterize
 
 
-class kacprzak_gen(beta_gen):
+class kacprzak_gen(stats._continuous_distns.beta_gen):
     r'''Galaxy ellipticities sampled from a reparameterized beta distribution.
 
     The ellipticities follow a beta distribution parameterized by
@@ -85,7 +85,8 @@ class kacprzak_gen(beta_gen):
         return super()._stats(*args)
 
     def fit(self, data, *args, **kwds):
-        return super(beta_gen, self).fit(data, *args, **kwds)
+        return super(stats._continuous_distns.beta_gen, self).fit(
+            data, *args, **kwds)
 
 
 kacprzak = kacprzak_gen(a=0.0, b=1.0, name='kacprzak')

--- a/skypy/galaxy/morphology.py
+++ b/skypy/galaxy/morphology.py
@@ -1,0 +1,55 @@
+"""Galaxy morphology module.
+
+This module provides facilities to sample the morphological properties of
+galaxies using a number of models.
+"""
+
+from scipy import stats
+
+
+def _kacprzak_input(beta_method):
+    def reparameterize(self, *args):
+        *beta_args, e_sum, e_ratio = args
+        a = e_sum * e_ratio
+        b = e_sum * (1.0 - e_ratio)
+        return beta_method(self, *beta_args, a, b)
+    return reparameterize
+
+
+def _kacprzak_output(beta_method):
+    def reparameterize(self, *args, **kwds):
+        a, b, *beta_out = beta_method(self, *args, **kwds)
+        e_sum = a + b
+        e_ratio = a / (a + b)
+        return (e_sum, e_ratio, *beta_out)
+    return reparameterize
+
+
+class ellipticity_beta_gen(stats._continuous_distns.beta_gen):
+
+    @_kacprzak_input
+    def _rvs(self, *args):
+        return super()._rvs(*args)
+
+    @_kacprzak_input
+    def _logpdf(self, *args):
+        return super()._logpdf(*args)
+
+    @_kacprzak_input
+    def _cdf(self, *args):
+        return super()._cdf(*args)
+
+    @_kacprzak_input
+    def _ppf(self, *args):
+        return super()._ppf(*args)
+
+    @_kacprzak_input
+    def _stats(self, *args):
+        return super()._stats(*args)
+
+    @_kacprzak_output
+    def fit(self, data, *args, **kwds):
+        return super().fit(data, *args, **kwds)
+
+
+ellipticity_beta = ellipticity_beta_gen(a=0.0, b=1.0, name='ellipticity_beta')

--- a/skypy/galaxy/morphology.py
+++ b/skypy/galaxy/morphology.py
@@ -4,10 +4,10 @@ This module provides facilities to sample the morphological properties of
 galaxies using a number of models.
 """
 
-from scipy import stats
+from scipy.stats._continuous_distns import beta_gen
 
 
-def _kacprzak_input(beta_method):
+def _kacprzak_parameterization(beta_method):
     def reparameterize(self, *args):
         *beta_args, e_sum, e_ratio = args
         a = e_sum * e_ratio
@@ -16,40 +16,30 @@ def _kacprzak_input(beta_method):
     return reparameterize
 
 
-def _kacprzak_output(beta_method):
-    def reparameterize(self, *args, **kwds):
-        a, b, *beta_out = beta_method(self, *args, **kwds)
-        e_sum = a + b
-        e_ratio = a / (a + b)
-        return (e_sum, e_ratio, *beta_out)
-    return reparameterize
+class ellipticity_beta_gen(beta_gen):
 
-
-class ellipticity_beta_gen(stats._continuous_distns.beta_gen):
-
-    @_kacprzak_input
+    @_kacprzak_parameterization
     def _rvs(self, *args):
         return super()._rvs(*args)
 
-    @_kacprzak_input
+    @_kacprzak_parameterization
     def _logpdf(self, *args):
         return super()._logpdf(*args)
 
-    @_kacprzak_input
+    @_kacprzak_parameterization
     def _cdf(self, *args):
         return super()._cdf(*args)
 
-    @_kacprzak_input
+    @_kacprzak_parameterization
     def _ppf(self, *args):
         return super()._ppf(*args)
 
-    @_kacprzak_input
+    @_kacprzak_parameterization
     def _stats(self, *args):
         return super()._stats(*args)
 
-    @_kacprzak_output
     def fit(self, data, *args, **kwds):
-        return super().fit(data, *args, **kwds)
+        return super(beta_gen, self).fit(data, *args, **kwds)
 
 
 ellipticity_beta = ellipticity_beta_gen(a=0.0, b=1.0, name='ellipticity_beta')

--- a/skypy/galaxy/tests/test_morphology.py
+++ b/skypy/galaxy/tests/test_morphology.py
@@ -7,54 +7,53 @@ from scipy.stats.tests.common_tests import (
     check_random_state_property, check_pickling)
 
 
-def test_ellipticity_beta():
+def test_kacprzak():
 
-    from skypy.galaxy.morphology import ellipticity_beta
+    from skypy.galaxy.morphology import kacprzak
 
     a, b = np.random.lognormal(size=2)
-    args = (a + b, a / (a + b))
-    beta = stats.beta(a, b)
-    kacprzak = ellipticity_beta(*args)
-    kacprzak_uniform = ellipticity_beta(2, 0.5)
-    kacprzak_arcsine = ellipticity_beta(1, 0.5)
+    args = (a / (a + b), a + b)
+    beta_dist = stats.beta(a, b)
+    kacprzak_dist = kacprzak(*args)
+    kacprzak_uniform = kacprzak(0.5, 2.0)
+    kacprzak_arcsine = kacprzak(0.5, 1.0)
 
     x = np.linspace(0, 1, 100)
-    intervals = np.linspace(0, 1, 100)
 
-    check_normalization(ellipticity_beta, args, 'ellipticity_beta')
-    check_edge_support(ellipticity_beta, args)
-    check_random_state_property(ellipticity_beta, args)
-    check_pickling(ellipticity_beta, args)
+    check_normalization(kacprzak, args, 'kacprzak')
+    check_edge_support(kacprzak, args)
+    check_random_state_property(kacprzak, args)
+    check_pickling(kacprzak, args)
 
-    m, v, s, k = kacprzak.stats(moments='mvsk')
-    check_mean_expect(ellipticity_beta, args, m, 'ellipticity_beta')
-    check_var_expect(ellipticity_beta, args, m, v, 'ellipticity_beta')
-    check_skew_expect(ellipticity_beta, args, m, v, s, 'ellipticity_beta')
-    check_kurt_expect(ellipticity_beta, args, m, v, k, 'ellipticity_beta')
-    check_moment(ellipticity_beta, args, m, v, 'ellipticity_beta')
+    m, v, s, k = kacprzak_dist.stats(moments='mvsk')
+    check_mean_expect(kacprzak, args, m, 'kacprzak')
+    check_var_expect(kacprzak, args, m, v, 'kacprzak')
+    check_skew_expect(kacprzak, args, m, v, s, 'kacprzak')
+    check_kurt_expect(kacprzak, args, m, v, k, 'kacprzak')
+    check_moment(kacprzak, args, m, v, 'kacprzak')
 
-    assert allclose(kacprzak.pdf(x), beta.pdf(x))
-    assert allclose(kacprzak.logpdf(x), beta.logpdf(x))
-    assert allclose(kacprzak.cdf(x), beta.cdf(x))
-    assert allclose(kacprzak.logcdf(x), beta.logcdf(x))
-    assert allclose(kacprzak.ppf(x), beta.ppf(x))
-    assert allclose(kacprzak.sf(x), beta.sf(x))
-    assert allclose(kacprzak.logsf(x), beta.logsf(x))
-    assert allclose(kacprzak.isf(x), beta.isf(x))
-    assert isclose(kacprzak.entropy(), beta.entropy())
-    assert isclose(kacprzak.median(), beta.median())
-    assert isclose(kacprzak.std(), beta.std())
-    assert allclose(kacprzak.interval(intervals), beta.interval(intervals))
+    assert allclose(kacprzak_dist.pdf(x), beta_dist.pdf(x))
+    assert allclose(kacprzak_dist.logpdf(x), beta_dist.logpdf(x))
+    assert allclose(kacprzak_dist.cdf(x), beta_dist.cdf(x))
+    assert allclose(kacprzak_dist.logcdf(x), beta_dist.logcdf(x))
+    assert allclose(kacprzak_dist.ppf(x), beta_dist.ppf(x))
+    assert allclose(kacprzak_dist.sf(x), beta_dist.sf(x))
+    assert allclose(kacprzak_dist.logsf(x), beta_dist.logsf(x))
+    assert allclose(kacprzak_dist.isf(x), beta_dist.isf(x))
+    assert isclose(kacprzak_dist.entropy(), beta_dist.entropy())
+    assert isclose(kacprzak_dist.median(), beta_dist.median())
+    assert isclose(kacprzak_dist.std(), beta_dist.std())
+    assert allclose(kacprzak_dist.interval(x), beta_dist.interval(x))
 
-    assert np.isscalar(kacprzak.rvs())
-    assert kacprzak.rvs(size=10).shape == (10,)
+    assert np.isscalar(kacprzak_dist.rvs())
+    assert kacprzak_dist.rvs(size=10).shape == (10,)
 
-    e_sum = 0.5 * np.ones((7, 5))
     e_ratio = 0.5 * np.ones((13, 1, 5))
-    rvs = ellipticity_beta.rvs(e_sum, e_ratio)
-    assert rvs.shape == np.broadcast(e_sum, e_ratio).shape
+    e_sum = 0.5 * np.ones((7, 5))
+    rvs = kacprzak.rvs(e_ratio, e_sum)
+    assert rvs.shape == np.broadcast(e_ratio, e_sum).shape
 
-    D, p = stats.kstest(kacprzak.rvs, beta.cdf, N=1000)
+    D, p = stats.kstest(kacprzak_dist.rvs, beta_dist.cdf, N=1000)
     assert p > 0.01, 'D = {}, p = {}'.format(D, p)
 
     D, p = stats.kstest(kacprzak_uniform.rvs, 'uniform', N=1000)

--- a/skypy/galaxy/tests/test_morphology.py
+++ b/skypy/galaxy/tests/test_morphology.py
@@ -1,0 +1,64 @@
+from astropy.units import allclose, isclose
+import numpy as np
+from scipy import stats
+from scipy.stats.tests.common_tests import (
+    check_normalization, check_moment, check_mean_expect, check_var_expect,
+    check_skew_expect, check_kurt_expect, check_edge_support,
+    check_random_state_property, check_pickling)
+
+
+def test_ellipticity_beta():
+
+    from skypy.galaxy.morphology import ellipticity_beta
+
+    a, b = np.random.lognormal(size=2)
+    args = (a + b, a / (a + b))
+    beta = stats.beta(a, b)
+    kacprzak = ellipticity_beta(*args)
+    kacprzak_uniform = ellipticity_beta(2, 0.5)
+    kacprzak_arcsine = ellipticity_beta(1, 0.5)
+
+    x = np.linspace(0, 1, 100)
+    intervals = np.linspace(0, 1, 100)
+
+    check_normalization(ellipticity_beta, args, 'ellipticity_beta')
+    check_edge_support(ellipticity_beta, args)
+    check_random_state_property(ellipticity_beta, args)
+    check_pickling(ellipticity_beta, args)
+
+    m, v, s, k = kacprzak.stats(moments='mvsk')
+    check_mean_expect(ellipticity_beta, args, m, 'ellipticity_beta')
+    check_var_expect(ellipticity_beta, args, m, v, 'ellipticity_beta')
+    check_skew_expect(ellipticity_beta, args, m, v, s, 'ellipticity_beta')
+    check_kurt_expect(ellipticity_beta, args, m, v, k, 'ellipticity_beta')
+    check_moment(ellipticity_beta, args, m, v, 'ellipticity_beta')
+
+    assert allclose(kacprzak.pdf(x), beta.pdf(x))
+    assert allclose(kacprzak.logpdf(x), beta.logpdf(x))
+    assert allclose(kacprzak.cdf(x), beta.cdf(x))
+    assert allclose(kacprzak.logcdf(x), beta.logcdf(x))
+    assert allclose(kacprzak.ppf(x), beta.ppf(x))
+    assert allclose(kacprzak.sf(x), beta.sf(x))
+    assert allclose(kacprzak.logsf(x), beta.logsf(x))
+    assert allclose(kacprzak.isf(x), beta.isf(x))
+    assert isclose(kacprzak.entropy(), beta.entropy())
+    assert isclose(kacprzak.median(), beta.median())
+    assert isclose(kacprzak.std(), beta.std())
+    assert allclose(kacprzak.interval(intervals), beta.interval(intervals))
+
+    assert np.isscalar(kacprzak.rvs())
+    assert kacprzak.rvs(size=10).shape == (10,)
+
+    e_sum = 0.5 * np.ones((7, 5))
+    e_ratio = 0.5 * np.ones((13, 1, 5))
+    rvs = ellipticity_beta.rvs(e_sum, e_ratio)
+    assert rvs.shape == np.broadcast(e_sum, e_ratio).shape
+
+    D, p = stats.kstest(kacprzak.rvs, beta.cdf, N=1000)
+    assert p > 0.01, 'D = {}, p = {}'.format(D, p)
+
+    D, p = stats.kstest(kacprzak_uniform.rvs, 'uniform', N=1000)
+    assert p > 0.01, 'D = {}, p = {}'.format(D, p)
+
+    D, p = stats.kstest(kacprzak_arcsine.rvs, 'arcsine', N=1000)
+    assert p > 0.01, 'D = {}, p = {}'.format(D, p)


### PR DESCRIPTION
## Description
Implements the ellipticity distribution of galaxies as a reparameterized beta distribution as presented in [Kacprzak et al. 2019](https://ui.adsabs.harvard.edu/abs/2019arXiv190601018K/abstract). Resolves #29 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/develop/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
