### PR TITLE
Galaxy Sizes

### DIFF
--- a/docs/galaxy/index.rst
+++ b/docs/galaxy/index.rst
@@ -3,21 +3,24 @@ Galaxies (`skypy.galaxy`)
 *************************
 
 
-Redshifts (`skypy.galaxy.redshift`)
-===================================
-
 Luminosities (`skypy.galaxy.luminosity`)
 ========================================
 
-Spectra ('skypy.galaxy.spectrum')
+Redshifts (`skypy.galaxy.redshift`)
 ===================================
+
+Sizes (`skypy.galaxy.size`)
+===========================
+
+Spectra ('skypy.galaxy.spectrum')
+=================================
 
 
 Reference/API
 =============
 
 .. automodapi:: skypy.galaxy
-.. automodapi:: skypy.galaxy.redshift
 .. automodapi:: skypy.galaxy.luminosity
+.. automodapi:: skypy.galaxy.redshift
+.. automodapi:: skypy.galaxy.size
 .. automodapi:: skypy.galaxy.spectrum
-

--- a/skypy/galaxy/size.py
+++ b/skypy/galaxy/size.py
@@ -1,0 +1,214 @@
+''' This modules computes the angular size of galaxies from
+their physical size.'''
+
+import numpy as np
+from astropy import units
+
+
+def angular_size(physical_size, redshift, cosmology):
+    '''Angular size of a galaxy.
+    This function transforms physical radius into angular distance, described
+    in [1].
+
+    Parameters
+    ----------
+    physical_size : astropy.Quantity
+        Physical radius of galaxies in units of length.
+    redshift : float
+        Redshifts at which to evaluate the angular diameter distance.
+    cosmology : astropy.cosmology.Cosmology
+        Cosmology object providing methods for the evolution history of
+        omega_matter and omega_lambda with redshift.
+
+    Results
+    -------
+    angular_size : astropy.Quantity
+        Angular distances in units of [rad] for a given radius.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from astropy import units
+    >>> from astropy.cosmology import FlatLambdaCDM
+    >>> cosmology = FlatLambdaCDM(H0=67.04, Om0=0.3183, Ob0=0.047745)
+    >>> size = 10.0 * units.kpc
+    >>> angular_size(size, 1, cosmology)
+    <Quantity 5.85990062e-06 rad>
+
+    References
+    ----------
+    .. [1] D. W. Hogg, (1999), astro-ph/9905116.
+    '''
+
+    distance = cosmology.angular_diameter_distance(redshift)
+    angular_size = np.arctan(physical_size / distance)
+
+    return angular_size
+
+
+def late_type_lognormal(magnitude, alpha, beta, gamma, M0, sigma1, sigma2,
+                        size=None):
+    '''Lognormal distribution for late-type galaxies.
+    This function provides a lognormal distribution for the physical size of
+    late-type galaxies, described by equations 12, 15 and 16 in [1].
+
+    Parameters
+    ----------
+    magnitude : float or array_like.
+        Galaxy magnitude at which evaluate the lognormal distribution.
+    alpha, beta, gamma, M0: float
+        Model parameters describing the mean size of galaxies in [kpc].
+        Equation 15 in [1].
+    sigma1, sigma2: float
+        Parameters describing the standard deviation of the lognormal
+        distribution for the physical radius of galaxies. Equation 16 in [1].
+    size : int or tuple of ints, optional.
+        Output shape. If the given shape is, e.g., (m, n, k),
+        then m * n * k samples are drawn. If size is None (default),
+        a single value is returned if mean and sigma are both scalars.
+        Otherwise, np.broadcast(mean, sigma).size samples are drawn.
+
+    Results
+    -------
+    physical_size : numpy.ndarray or astropy.Quantity
+        Physical distance for a given galaxy with a given magnitude, in [kpc].
+        If size is None and magnitude is a scalar, a single sample is returned.
+        If size is different from None and magnitude is scalar,
+        shape is (size,). If magnitude has shape (nm,) and size=None,
+        shape is (nm,).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skypy.galaxy import size
+    >>> np.random.seed(12345)
+    >>> magnitude = -16.0
+    >>> alpha, beta, gamma, M0 = 0.21, 0.53, -1.31, -20.52
+    >>> sigma1, sigma2 = 0.48, 0.25
+    >>> size.late_type_lognormal(magnitude, alpha, beta, gamma, M0,\
+                                 sigma1, sigma2)
+    <Quantity 0.9850926 kpc>
+
+
+    References
+    ----------
+    ..[1] S. Shen, H.J. Mo, S.D.M. White, M.R. Blanton, G. Kauffmann, W. Voges,
+        J. Brinkmann, I. Csabai, Mon. Not. Roy. Astron. Soc. 343, 978 (2003).
+    '''
+
+    if size is None and np.shape(magnitude):
+        size = np.shape(magnitude)
+
+    r_bar = np.power(10, -0.4 * alpha * magnitude + (beta - alpha) *
+                     np.log10(1 + np.power(10, -0.4 * (magnitude - M0)))
+                     + gamma) * units.kpc
+
+    sigma_lnR = sigma2 + (sigma1 - sigma2) /\
+                         (1.0 + np.power(10, -0.8 * (magnitude - M0)))
+
+    return r_bar * np.random.lognormal(sigma=sigma_lnR, size=size)
+
+
+def early_type_lognormal(magnitude, a, b, M0, sigma1, sigma2, size=None):
+    '''Lognormal distribution for early-type galaxies.
+    This function provides a lognormal distribution for the physical size of
+    early-type galaxies, described by equations 12, 14 and 16 in [1].
+
+    Parameters
+    ----------
+    magnitude : float or array_like.
+        Galaxy magnitude at which evaluate the lognormal distribution.
+    a_mu, b_mu : float
+        Linear model parameters describing the mean size of galaxies,
+        equation 3.14 in [1].
+    sigma: float
+        Standard deviation of the lognormal distribution for the
+        physical radius of galaxies.
+    size : int or tuple of ints, optional.
+        Output shape. If the given shape is, e.g., (m, n, k),
+        then m * n * k samples are drawn. If size is None (default),
+        a single value is returned if mean and sigma are both scalars.
+        Otherwise, np.broadcast(mean, sigma).size samples are drawn.
+
+    Results
+    -------
+    physical_size : ndarray or astropy.Quantity
+        Physical distance for a given galaxy with a given magnitude, in [kpc].
+        If size is None and magnitude is a scalar, a single sample is returned.
+        If size is different from None and magnitude is scalar,
+        shape is (size,). If magnitude has shape (nm,) and size=None,
+        shape is (nm,).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skypy.galaxy import size
+    >>> np.random.seed(12345)
+    >>> magnitude = -20.0
+    >>> a, b, M0 = 0.6, -4.63, -20.52
+    >>> sigma1, sigma2 = 0.48, 0.25
+    >>> size.early_type_lognormal(magnitude, a, b, M0, sigma1, sigma2)
+    <Quantity 1.35830285 kpc>
+
+
+    References
+    ----------
+    ..[1] S. Shen, H.J. Mo, S.D.M. White, M.R. Blanton, G. Kauffmann, W. Voges,
+        J. Brinkmann, I. Csabai, Mon. Not. Roy. Astron. Soc. 343, 978 (2003).
+        '''
+
+    return late_type_lognormal(magnitude, a, a, b, M0, sigma1, sigma2,
+                               size=size)
+
+
+def linear_lognormal(magnitude, a_mu, b_mu, sigma, size=None):
+    '''Lognormal distribution with linear mean.
+    This function provides a lognormal distribution for the physical size of
+    galaxies with a linear mean, described by equation 3.14 in [1]. See also
+    equation 14 in [2].
+
+    Parameters
+    ----------
+    magnitude : float or array_like.
+        Galaxy magnitude at which evaluate the lognormal distribution.
+    a_mu, b_mu : float
+        Linear model parameters describing the mean size of galaxies,
+        equation 3.14 in [1].
+    sigma: float
+        Standard deviation of the lognormal distribution for the
+        physical radius of galaxies.
+    size : int or tuple of ints, optional.
+        Output shape. If the given shape is, e.g., (m, n, k),
+        then m * n * k samples are drawn. If size is None (default),
+        a single value is returned if mean and sigma are both scalars.
+        Otherwise, np.broadcast(mean, sigma).size samples are drawn.
+
+    Results
+    -------
+    physical_size : numpy.ndarray or astropy.Quantity
+        Physical distance for a given galaxy with a given magnitude, in [kpc].
+        If size is None and magnitude is a scalar, a single sample is returned.
+        If size is different from None and magnitude is scalar,
+        shape is (size,). If magnitude has shape (nm,) and size=None,
+        shape is (nm,).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from skypy.galaxy import size
+    >>> np.random.seed(12345)
+    >>> magnitude = -20.0
+    >>> a_mu, b_mu, sigma =-0.24, -4.63, 0.4
+    >>> size.linear_lognormal(magnitude, a_mu, b_mu, sigma)
+    <Quantity 1.36282044 kpc>
+
+    References
+    ----------
+    ..[1] J. Herbel, T. Kacprzak, A. Amara, A. Refregier, C.Bruderer and
+           A. Nicola, JCAP 1708, 035 (2017).
+    ..[2] S. Shen, H.J. Mo, S.D.M. White, M.R. Blanton, G. Kauffmann, W.Voges,
+           J. Brinkmann, I.Csabai, Mon. Not. Roy. Astron. Soc. 343, 978 (2003).
+    '''
+
+    return late_type_lognormal(magnitude, -a_mu / 0.4, -a_mu / 0.4,
+                               b_mu, -np.inf, sigma, sigma, size=size)

--- a/skypy/galaxy/size.py
+++ b/skypy/galaxy/size.py
@@ -1,12 +1,12 @@
-''' This modules computes the angular size of galaxies from
-their physical size.'''
+""" This modules computes the angular size of galaxies from
+their physical size."""
 
 import numpy as np
 from astropy import units
 
 
 def angular_size(physical_size, redshift, cosmology):
-    '''Angular size of a galaxy.
+    """Angular size of a galaxy.
     This function transforms physical radius into angular distance, described
     in [1].
 
@@ -38,7 +38,7 @@ def angular_size(physical_size, redshift, cosmology):
     References
     ----------
     .. [1] D. W. Hogg, (1999), astro-ph/9905116.
-    '''
+    """
 
     distance = cosmology.angular_diameter_distance(redshift)
     angular_size = np.arctan(physical_size / distance)
@@ -48,7 +48,7 @@ def angular_size(physical_size, redshift, cosmology):
 
 def late_type_lognormal(magnitude, alpha, beta, gamma, M0, sigma1, sigma2,
                         size=None):
-    '''Lognormal distribution for late-type galaxies.
+    """Lognormal distribution for late-type galaxies.
     This function provides a lognormal distribution for the physical size of
     late-type galaxies, described by equations 12, 15 and 16 in [1].
 
@@ -73,8 +73,8 @@ def late_type_lognormal(magnitude, alpha, beta, gamma, M0, sigma1, sigma2,
     physical_size : numpy.ndarray or astropy.Quantity
         Physical distance for a given galaxy with a given magnitude, in [kpc].
         If size is None and magnitude is a scalar, a single sample is returned.
-        If size is different from None and magnitude is scalar,
-        shape is (size,). If magnitude has shape (nm,) and size=None,
+        If size is ns, different from None, and magnitude is scalar,
+        shape is (ns,). If magnitude has shape (nm,) and size=None,
         shape is (nm,).
 
     Examples
@@ -94,7 +94,7 @@ def late_type_lognormal(magnitude, alpha, beta, gamma, M0, sigma1, sigma2,
     ----------
     ..[1] S. Shen, H.J. Mo, S.D.M. White, M.R. Blanton, G. Kauffmann, W. Voges,
         J. Brinkmann, I. Csabai, Mon. Not. Roy. Astron. Soc. 343, 978 (2003).
-    '''
+    """
 
     if size is None and np.shape(magnitude):
         size = np.shape(magnitude)
@@ -110,7 +110,7 @@ def late_type_lognormal(magnitude, alpha, beta, gamma, M0, sigma1, sigma2,
 
 
 def early_type_lognormal(magnitude, a, b, M0, sigma1, sigma2, size=None):
-    '''Lognormal distribution for early-type galaxies.
+    """Lognormal distribution for early-type galaxies.
     This function provides a lognormal distribution for the physical size of
     early-type galaxies, described by equations 12, 14 and 16 in [1].
 
@@ -118,7 +118,7 @@ def early_type_lognormal(magnitude, a, b, M0, sigma1, sigma2, size=None):
     ----------
     magnitude : float or array_like.
         Galaxy magnitude at which evaluate the lognormal distribution.
-    a_mu, b_mu : float
+    a, b : float
         Linear model parameters describing the mean size of galaxies,
         equation 3.14 in [1].
     sigma: float
@@ -135,8 +135,8 @@ def early_type_lognormal(magnitude, a, b, M0, sigma1, sigma2, size=None):
     physical_size : ndarray or astropy.Quantity
         Physical distance for a given galaxy with a given magnitude, in [kpc].
         If size is None and magnitude is a scalar, a single sample is returned.
-        If size is different from None and magnitude is scalar,
-        shape is (size,). If magnitude has shape (nm,) and size=None,
+        If size is ns, different from None, and magnitude is scalar,
+        shape is (ns,). If magnitude has shape (nm,) and size=None,
         shape is (nm,).
 
     Examples
@@ -155,14 +155,14 @@ def early_type_lognormal(magnitude, a, b, M0, sigma1, sigma2, size=None):
     ----------
     ..[1] S. Shen, H.J. Mo, S.D.M. White, M.R. Blanton, G. Kauffmann, W. Voges,
         J. Brinkmann, I. Csabai, Mon. Not. Roy. Astron. Soc. 343, 978 (2003).
-        '''
+    """
 
     return late_type_lognormal(magnitude, a, a, b, M0, sigma1, sigma2,
                                size=size)
 
 
 def linear_lognormal(magnitude, a_mu, b_mu, sigma, size=None):
-    '''Lognormal distribution with linear mean.
+    """Lognormal distribution with linear mean.
     This function provides a lognormal distribution for the physical size of
     galaxies with a linear mean, described by equation 3.14 in [1]. See also
     equation 14 in [2].
@@ -170,7 +170,7 @@ def linear_lognormal(magnitude, a_mu, b_mu, sigma, size=None):
     Parameters
     ----------
     magnitude : float or array_like.
-        Galaxy magnitude at which evaluate the lognormal distribution.
+        Galaxy absolute magnitude at which evaluate the lognormal distribution.
     a_mu, b_mu : float
         Linear model parameters describing the mean size of galaxies,
         equation 3.14 in [1].
@@ -188,8 +188,8 @@ def linear_lognormal(magnitude, a_mu, b_mu, sigma, size=None):
     physical_size : numpy.ndarray or astropy.Quantity
         Physical distance for a given galaxy with a given magnitude, in [kpc].
         If size is None and magnitude is a scalar, a single sample is returned.
-        If size is different from None and magnitude is scalar,
-        shape is (size,). If magnitude has shape (nm,) and size=None,
+        If size is ns, different from None, and magnitude is scalar,
+        shape is (ns,). If magnitude has shape (nm,) and size=None,
         shape is (nm,).
 
     Examples
@@ -208,7 +208,7 @@ def linear_lognormal(magnitude, a_mu, b_mu, sigma, size=None):
            A. Nicola, JCAP 1708, 035 (2017).
     ..[2] S. Shen, H.J. Mo, S.D.M. White, M.R. Blanton, G. Kauffmann, W.Voges,
            J. Brinkmann, I.Csabai, Mon. Not. Roy. Astron. Soc. 343, 978 (2003).
-    '''
+    """
 
     return late_type_lognormal(magnitude, -a_mu / 0.4, -a_mu / 0.4,
                                b_mu, -np.inf, sigma, sigma, size=size)

--- a/skypy/galaxy/tests/test_size.py
+++ b/skypy/galaxy/tests/test_size.py
@@ -38,6 +38,7 @@ def test_late_type_lognormal():
                                            gamma, M0, sigma1, sigma2)
 
     assert np.isscalar(size_scalar.value)
+
     # Test that the output has the correct units
     assert size_scalar.unit.is_equivalent(units.kpc)
 
@@ -78,6 +79,7 @@ def test_early_type_lognormal():
                                             sigma1, sigma2)
 
     assert np.isscalar(size_scalar.value)
+
     # Test that the output has the correct units
     assert size_scalar.unit.is_equivalent(units.kpc)
 
@@ -113,6 +115,7 @@ def test_linear_lognormal():
     size_scalar = size.linear_lognormal(magnitude_scalar, a_mu, b_mu, sigma)
 
     assert np.isscalar(size_scalar.value)
+
     # Test that the output has the correct units
     assert size_scalar.unit.is_equivalent(units.kpc)
 

--- a/skypy/galaxy/tests/test_size.py
+++ b/skypy/galaxy/tests/test_size.py
@@ -1,0 +1,136 @@
+import numpy as np
+from astropy import units
+from scipy import stats
+import pytest
+
+from astropy.cosmology import FlatLambdaCDM
+from skypy.galaxy import size
+
+
+def test_angular_size():
+    """ Test a FlatLambdaCDM cosmology with omega_matter = 1"""
+    cosmology = FlatLambdaCDM(Om0=1.0, H0=70.0)
+
+    # Test that a scalar input gives a scalar output
+    scalar_radius = 1.0 * units.kpc
+    scalar_redshift = 1.0
+    angular_size = size.angular_size(scalar_radius, scalar_redshift, cosmology)
+
+    assert np.isscalar(angular_size.value)
+
+    # Test that the output has the correct units
+    assert angular_size.unit.is_equivalent(units.rad)
+
+    # If the input have bad units, a UnitConversionError is raised
+    radius_without_units = 1.0
+
+    with pytest.raises(units.UnitTypeError):
+        size.angular_size(radius_without_units, scalar_redshift, cosmology)
+
+
+def test_late_type_lognormal():
+    """ Test lognormal distribution of late-type galaxy sizes"""
+    # Test that a scalar input gives a scalar output
+    magnitude_scalar = -20.0
+    alpha, beta, gamma, M0 = 0.21, 0.53, -1.31, -20.52
+    sigma1, sigma2 = 0.48, 0.25
+    size_scalar = size.late_type_lognormal(magnitude_scalar, alpha, beta,
+                                           gamma, M0, sigma1, sigma2)
+
+    assert np.isscalar(size_scalar.value)
+    # Test that the output has the correct units
+    assert size_scalar.unit.is_equivalent(units.kpc)
+
+    # Test that an array input gives an array output, with the same shape
+    magnitude_array = np.array([-20.0, -21.0])
+    size_array = size.late_type_lognormal(magnitude_array, alpha, beta, gamma,
+                                          M0, sigma1, sigma2)
+
+    assert np.shape(size_array.value) == np.shape(magnitude_array)
+
+    # Test that size not None gives an array output, with the correct shape
+    size_sample = size.late_type_lognormal(magnitude_scalar, alpha, beta,
+                                           gamma, M0, sigma1, sigma2,
+                                           size=1000)
+
+    assert np.shape(size_sample.value) == (1000,)
+
+    # Test the distribution of galaxy sizes follows a lognormal distribution
+    mean = -0.4 * alpha * magnitude_scalar + (beta - alpha) *\
+        np.log10(1 + np.power(10, -0.4 * (magnitude_scalar - M0)))\
+        + gamma
+    sigma = sigma2 + (sigma1 - sigma2) /\
+        (1.0 + np.power(10, -0.8 * (magnitude_scalar - M0)))
+
+    arguments = (sigma, 0, np.power(10, mean))
+    d, p = stats.kstest(size_sample, 'lognorm', args=arguments)
+
+    assert p > 0.01
+
+
+def test_early_type_lognormal():
+    """ Test lognormal distribution of late-type galaxy sizes"""
+    # Test that a scalar input gives a scalar output
+    magnitude_scalar = -20.0
+    a, b, M0 = 0.6, -4.63, -20.52
+    sigma1, sigma2 = 0.48, 0.25
+    size_scalar = size.early_type_lognormal(magnitude_scalar, a, b, M0,
+                                            sigma1, sigma2)
+
+    assert np.isscalar(size_scalar.value)
+    # Test that the output has the correct units
+    assert size_scalar.unit.is_equivalent(units.kpc)
+
+    # Test that an array input gives an array output, with the same shape
+    magnitude_array = np.array([-20.0, -21.0])
+    size_array = size.early_type_lognormal(magnitude_array, a, b, M0,
+                                           sigma1, sigma2)
+
+    assert np.shape(size_array.value) == np.shape(magnitude_array)
+
+    # Test that size not None gives an array output, with the correct shape
+    size_sample = size.early_type_lognormal(magnitude_scalar, a, b, M0,
+                                            sigma1, sigma2, size=1000)
+
+    assert np.shape(size_sample.value) == (1000,)
+
+    # Test the distribution of galaxy sizes follows a lognormal distribution
+    mean = -0.4 * a * magnitude_scalar + b
+    sigma = sigma2 + (sigma1 - sigma2) /\
+                     (1.0 + np.power(10, -0.8 * (magnitude_scalar - M0)))
+
+    arguments = (sigma, 0, np.power(10, mean))
+    d, p = stats.kstest(size_sample, 'lognorm', args=arguments)
+
+    assert p > 0.01
+
+
+def test_linear_lognormal():
+    """ Test lognormal distribution of galaxy sizes"""
+    # Test that a scalar input gives a scalar output
+    magnitude_scalar = -20.0
+    a_mu, b_mu, sigma = -0.24, -4.63, 0.4
+    size_scalar = size.linear_lognormal(magnitude_scalar, a_mu, b_mu, sigma)
+
+    assert np.isscalar(size_scalar.value)
+    # Test that the output has the correct units
+    assert size_scalar.unit.is_equivalent(units.kpc)
+
+    # Test that an array input gives an array output, with the same shape
+    magnitude_array = np.array([-20.0, -21.0])
+    size_array = size.linear_lognormal(magnitude_array, a_mu, b_mu, sigma)
+
+    assert np.shape(size_array.value) == np.shape(magnitude_array)
+
+    # Test that size not None gives an array output, with the correct shape
+    size_sample = size.linear_lognormal(magnitude_scalar, a_mu, b_mu, sigma,
+                                        size=1000)
+
+    assert np.shape(size_sample.value) == (1000,)
+
+    # Test the distribution of galaxy sizes follows a lognormal distribution
+    mean = a_mu * magnitude_scalar + b_mu
+    arguments = (sigma, 0, np.power(10, mean))
+    d, p = stats.kstest(size_sample, 'lognorm', args=arguments)
+
+    assert p > 0.01


### PR DESCRIPTION
## Description
This module computes the angular size of galaxies from their physical size, as described in [1], [2] and [3]. It addresses issue #6  , previous discussion here #73.

## References
* [1] D. W. Hogg, (1999), astro-ph/9905116.
* [2] J. Herbel, T. Kacprzak, A. Amara, A. Refregier, C.Bruderer and
           A. Nicola, JCAP 1708, 035 (2017).
* [3] S. Shen, H.J. Mo, S.D.M. White, M.R. Blanton, G. Kauffmann, W.Voges,
           J. Brinkmann, I.Csabai, Mon. Not. Roy. Astron. Soc. 343, 978 (2003).

## Checklist
- [X] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/develop/CONTRIBUTING.md)
- [X] Write unit tests
- [X] Write documentation strings
- [X] Assign someone from your working team to review this pull request
- [X] Assign someone from the infrastructure team to review this pull request
