### PR TITLE
Fix growth_function_carroll doctest with astropy 4.x

### DIFF
--- a/skypy/power_spectrum/growth.py
+++ b/skypy/power_spectrum/growth.py
@@ -48,7 +48,7 @@ def growth_function_carroll(redshift, cosmology):
     >>> from astropy.cosmology import default_cosmology
     >>> redshift = np.array([0, 1, 2])
     >>> cosmology = default_cosmology.get()
-    >>> growth_function_carroll(redshift, cosmology) # doctest: +ELLIPSIS
+    >>> growth_function_carroll(redshift, cosmology)
     array([0.781361..., 0.476280..., 0.327549...])
 
     References

--- a/skypy/power_spectrum/growth.py
+++ b/skypy/power_spectrum/growth.py
@@ -48,8 +48,8 @@ def growth_function_carroll(redshift, cosmology):
     >>> from astropy.cosmology import default_cosmology
     >>> redshift = np.array([0, 1, 2])
     >>> cosmology = default_cosmology.get()
-    >>> growth_function_carroll(redshift, cosmology)
-    array([0.78136173, 0.47628062, 0.32754955])
+    >>> growth_function_carroll(redshift, cosmology) # doctest: +ELLIPSIS
+    array([0.781361..., 0.476280..., 0.327549...])
 
     References
     ----------


### PR DESCRIPTION
## Description
The doctest for growth_function_carroll gives different outputs using astropy 3.x and 4.x to within algorithmic precision. Use doctest: +ELLIPSIS to effectively lower the precision required on the test output so that it passes in both cases. Fixes #91.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/develop/CONTRIBUTING.md)
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
