### PR TITLE
Fix halo mass documentation

### DIFF
--- a/docs/halo/index.rst
+++ b/docs/halo/index.rst
@@ -9,3 +9,9 @@ Abundance Matching (`skypy.halo.abundance_matching`)
 ====================================================
 
 .. automodule:: skypy.halo.abundance_matching
+
+
+Mass (`skypy.halo.mass`)
+========================
+
+.. automodule:: skypy.halo.mass

--- a/skypy/halo/mass.py
+++ b/skypy/halo/mass.py
@@ -1,10 +1,17 @@
-r'''Models of galaxy masses.
+r'''Halo mass module.
+
+This module provides methods to sample the  masses of dark matter halos.
+
 Models
 ======
+
 .. autosummary::
+
    :nosignatures:
    :toctree: ../api/
+
    press_schechter
+
 '''
 
 import numpy as np

--- a/skypy/halo/mass.py
+++ b/skypy/halo/mass.py
@@ -25,7 +25,7 @@ def press_schechter(n, m_star, size=None, x_min=0.00305,
 
     Masses following the Press-Schechter mass function following the
     Press et al. [1]_ formalism.
-    
+
     Parameters
     ----------
     n : float or int
@@ -38,7 +38,7 @@ def press_schechter(n, m_star, size=None, x_min=0.00305,
         Lower and upper bounds in units of M*.
     resolution : int, optional
         Resolution of the inverse transform sampling spline. Default is 100.
-        
+
     Returns
     -------
     mass : array_like
@@ -54,7 +54,7 @@ def press_schechter(n, m_star, size=None, x_min=0.00305,
     References
     ----------
     .. [1] Press, W. H. and Schechter, P., APJ, (1974).
-    
+
     """
 
     alpha = - 0.5 * (n + 9.0) / (n + 3.0)

--- a/skypy/halo/mass.py
+++ b/skypy/halo/mass.py
@@ -21,11 +21,11 @@ from skypy.utils.random import schechter
 
 def press_schechter(n, m_star, size=None, x_min=0.00305,
                     x_max=1100.0, resolution=100):
-
     """Sampling from Press-Schechter mass function (1974).
 
     Masses following the Press-Schechter mass function following the
     Press et al. [1]_ formalism.
+    
     Parameters
     ----------
     n : float or int
@@ -38,6 +38,7 @@ def press_schechter(n, m_star, size=None, x_min=0.00305,
         Lower and upper bounds in units of M*.
     resolution : int, optional
         Resolution of the inverse transform sampling spline. Default is 100.
+        
     Returns
     -------
     mass : array_like
@@ -53,6 +54,7 @@ def press_schechter(n, m_star, size=None, x_min=0.00305,
     References
     ----------
     .. [1] Press, W. H. and Schechter, P., APJ, (1974).
+    
     """
 
     alpha = - 0.5 * (n + 9.0) / (n + 3.0)


### PR DESCRIPTION
## Description
Documentation for `skypy.halo.mass` was not rendering. Now fixed. See #99.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Assign someone from the infrastructure team to review this pull request
