### PR TITLE
Docstring for `skypy/init.py`

### DIFF
--- a/skypy/__init__.py
+++ b/skypy/__init__.py
@@ -1,13 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-# Packages may add whatever they like to this file, but
-# should keep this content at the top.
 """
 Skypy is a package offering core functionality and common tools for
 astronomical forward-modelling in Python. It contains methods for modelling
 the Universe, galaxies and the Milky Way and for generating synthetic
 observational data.
 """
+
+# Packages may add whatever they like to this file, but
+# should keep this content at the top.
 # ----------------------------------------------------------------------------
 from ._astropy_init import *   # noqa
 # ----------------------------------------------------------------------------

--- a/skypy/__init__.py
+++ b/skypy/__init__.py
@@ -1,7 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Skypy is a package offering core functionality and common tools for
+astronomical forward-modelling in Python. It contains methods for modelling
+the Universe, galaxies and the Milky Way and for generating synthetic
+observational data.
+"""
 
-# Packages may add whatever they like to this file, but
-# should keep this content at the top.
 # ----------------------------------------------------------------------------
 from ._astropy_init import *   # noqa
 # ----------------------------------------------------------------------------
@@ -26,6 +30,7 @@ if LooseVersion(sys.version) < LooseVersion(__minimum_python_version__):
 
 if not _ASTROPY_SETUP_:   # noqa
     # For egg_info test builds to pass, put package imports here.
+    from .example_mod import *   # noqa
     # Then you can be explicit to control what ends up in the namespace,
     __all__ += ['do_primes']   # noqa
     # or you can keep everything from the subpackage with the following instead

--- a/skypy/__init__.py
+++ b/skypy/__init__.py
@@ -1,11 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# Packages may add whatever they like to this file, but
+# should keep this content at the top.
 """
 Skypy is a package offering core functionality and common tools for
 astronomical forward-modelling in Python. It contains methods for modelling
 the Universe, galaxies and the Milky Way and for generating synthetic
 observational data.
 """
-
 # ----------------------------------------------------------------------------
 from ._astropy_init import *   # noqa
 # ----------------------------------------------------------------------------
@@ -30,7 +32,6 @@ if LooseVersion(sys.version) < LooseVersion(__minimum_python_version__):
 
 if not _ASTROPY_SETUP_:   # noqa
     # For egg_info test builds to pass, put package imports here.
-    from .example_mod import *   # noqa
     # Then you can be explicit to control what ends up in the namespace,
     __all__ += ['do_primes']   # noqa
     # or you can keep everything from the subpackage with the following instead


### PR DESCRIPTION
## Description
This PR fixes the docstring for the whole package to the top-level `./skypy/init.py`. Partly addresses issue #99 
## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
