### PR TITLE
Add code owners for new v0.2 modules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,8 @@
 skypy @skypyproject/skypy-infrastructure
+skypy/cluster @skypyproject/cluster-developers
 skypy/galaxy @skypyproject/galaxy-developers
+skypy/gravitational_wave @skypyproject/gravitational-wave-developers
 skypy/halo @skypyproject/halo-developers
 skypy/power_spectrum @skypyproject/power-spectrum-developers
+skypy/supernova @skypyproject/supernova-developers
 CODE_OF_CONDUCT.md @skypyproject/skypy-board


### PR DESCRIPTION
## Description
Add developer teams as code owners for the new cluster, gravitational_wave and supernova modules. Resolves #154 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Assign someone from the infrastructure team to review this pull request
