### PR TITLE
Simple filters for observations.

### DIFF
--- a/skypy/observation/__init__.py
+++ b/skypy/observation/__init__.py
@@ -1,0 +1,4 @@
+'''This module contains information about observations, such as instruments,
+filters, etc'''
+
+from ._filter import *  # noqa F401,F403

--- a/skypy/observation/_filter.py
+++ b/skypy/observation/_filter.py
@@ -1,0 +1,87 @@
+import numpy as np
+import scipy.interpolate
+
+
+__all__ = [
+    'no_filter',
+    'bandpass_filter',
+    'interpolated_filter'
+]
+
+
+def no_filter():
+    '''No filter.
+
+    The response of the `no_filter` function is identically unity.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+    A filter function that returns `1.0` in the same shape as the input array
+    for all inputs except `nan`.
+
+    '''
+
+    return lambda x: 1 - np.isnan(x)
+
+
+def bandpass_filter(a, b):
+    '''A bandpass filter.
+
+    The bandpass filter function returns `1.0` for wavelengths `a <= lam < b`
+    and `0.0` otherwise. Lowpass and highpass filters can have either bound at
+    infinity.
+
+    Multiple filter bands can be specified by passing arrays as upper and lower
+    bounds. In this case, the filter function will return a transmission curve
+    in the shape `(nlam, nband)`.
+
+    Parameters
+    ----------
+    a : float or array_like
+        Lower bound in desired units. Can be `-inf` for lowpass filters.
+    b : float or array_like
+        Upper bound in desired units. Can be `inf` for highpass filters.
+
+    Returns
+    -------
+    A filter function that creates a bandpass filter for a single or multiple
+    bands.
+
+    '''
+    def shape_expand_left(x, y):
+        return (*np.ones_like(np.shape(x), int), *np.shape(y))
+
+    def shape_expand_right(x, y):
+        return (*np.shape(x), *np.ones_like(np.shape(y), int))
+
+    return lambda x: (
+            np.less_equal(np.reshape(a, shape_expand_right(a, x)),
+                          np.reshape(x, shape_expand_left(a, x)))
+            & np.less(np.reshape(x, shape_expand_left(b, x)),
+                      np.reshape(b, shape_expand_right(b, x)))
+        ).astype(float)
+
+
+def interpolated_filter(x, Rx):
+    '''Filter from tabulated transmission curve.
+
+    Takes an array `x` and one or more transmission curves `Rx` and returns
+    an interpolated filter function for the bands.
+
+    Parameters
+    ----------
+    x : array_like of shape (nx,)
+        The spectral axis for the filter, typically frequency or wavelength.
+    Rx : array_like of shape (nx,) or (nfilt, nx)
+        The filter response curves, either for a single or multiple bands.
+
+    Returns
+    -------
+    A interpolation filter function.
+    '''
+
+    return scipy.interpolate.interp1d(x, Rx,
+                                      bounds_error=False, fill_value=0.0)

--- a/skypy/observation/tests/test_filter.py
+++ b/skypy/observation/tests/test_filter.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+from skypy.observation import (no_filter, bandpass_filter, interpolated_filter)
+
+
+def test_no_filter():
+    # the filter always returns one, except for nan, so make sure it handles
+    # input shapes correctly
+    filt = no_filter()
+    R = filt(1.0)
+    assert np.isscalar(R) and R == 1.0
+
+    R = filt([1., 2., 3.])
+    assert np.shape(R) == (3,) and np.all(R == 1.0)
+
+    R = filt([1., 2., np.nan])
+    assert np.shape(R) == (3,) and np.all(R == [1., 1., 0.])
+
+
+def test_bandpass_filter():
+    # bandpass filters can take single or multiple bands
+    filt = bandpass_filter(0, 1)
+    R = filt(0.0)
+    assert np.isscalar(R) and R == 1.0
+    R = filt(0.5)
+    assert np.isscalar(R) and R == 1.0
+    R = filt(1.0)
+    assert np.isscalar(R) and R == 0.0
+
+    filt = bandpass_filter([0, 1, 2, 3], [1, 2, 3, 4])
+    R = filt(0.5)
+    assert np.shape(R) == (4,) and np.all(R == [1., 0., 0., 0.])
+    R = filt([0.5, 1.5, 2.5, 3.5])
+    assert np.shape(R) == (4, 4) and np.all(R == np.eye(4))
+
+
+def test_interpolated_filter():
+    # takes one or more transmission curves and interpolates
+    x = [0., 1., 2., 3., 4.]
+    R1 = [1., 1., 0., 0., 0.]
+    R2 = [0., 1., 1., 0., 0.]
+    R3 = [0., 0., 1., 1., 0.]
+
+    filt = interpolated_filter(x, [R1, R2, R3])
+
+    R = filt(0.5)
+    assert np.shape(R) == (3,) and np.all(R == [1., 0.5, 0.])
+
+    R = filt([0.5, 1.5, 2.5, 3.5, 4.5])
+    assert np.shape(R) == (3, 5) and np.all(R == [[1.0, 0.5, 0.0, 0.0, 0.0],
+                                                  [0.5, 1.0, 0.5, 0.0, 0.0],
+                                                  [0.0, 0.5, 1.0, 0.5, 0.0]])


### PR DESCRIPTION
## Description

This is code salvage from our pre-skypy tests to define filter functions. Provided are meta-functions that return filter functions to be then used in spectrum integration, i.e. potentially helpful for #141. Currently only has `no_filter`, `bandpass_filter`, and `interpolated_filter`, with bandpass the only nontrivial one.

Here is how these were used:

```py
def flux(lam, sed, filt):
    return np.trapz(sed*filt(lam), lam)

def fluxAB(lam, filt):
    return 3.6308e-20*u.erg/u.second/u.cm**2/u.Hz*np.trapz(filt(lam)*c.c/lam**2, lam)

Rlam, Ru, Rg, Rr, Ri, Rz, Ratm = np.loadtxt('STD_BANDPASSES_DR1.dat').T

filt = interpolated_filter(Rlam, [Ru, Rg, Rr, Ri, Rz])

f = flux(lam, sed, filt)
f0 = fluxAB(Rlam, filt)

mag = -2.5*np.log10(f/f0)
```

The code is in a new module `skypy.observation` that subsequently needs to be fleshed out with docs etc. This PR is meant as a potential quick help for the colours integration. If accepted, issues should be created to add standard filters (SDSS, Johnson, ...) etc. for convenience.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request