### PR TITLE
absolute magnitude standard band zeropoints

### DIFF
--- a/skypy/galaxy/luminosity.py
+++ b/skypy/galaxy/luminosity.py
@@ -105,9 +105,9 @@ def herbel_luminosities(redshift, alpha, a_m, b_m, size=None,
         size = np.shape(redshift)
 
     # this is the AB zeropoint of the B-band in units of solar luminosity
-    zeropt = -4.73
+    zeropoint = -4.73
 
-    luminosity_star = _calculate_luminosity_star(redshift, a_m, b_m, zeropt)
+    luminosity_star = _calculate_luminosity_star(redshift, a_m, b_m, zeropoint)
 
     x_sample = schechter(alpha, x_min, x_max, resolution=resolution, size=size)
 

--- a/skypy/galaxy/luminosity.py
+++ b/skypy/galaxy/luminosity.py
@@ -15,7 +15,7 @@ __all__ = [
 
 def herbel_luminosities(redshift, alpha, a_m, b_m, size=None,
                         x_min=0.00305,
-                        x_max=1100.0, resolution=100, band=None):
+                        x_max=1100.0, resolution=100):
 
     r"""Model of Herbel et al (2017)
 
@@ -40,15 +40,12 @@ def herbel_luminosities(redshift, alpha, a_m, b_m, size=None,
         Lower and upper luminosity bounds in units of L*.
     resolution : int, optional
         Resolution of the inverse transform sampling spline. Default is 100.
-    band : str, optional
-        Filter band for absolute magnitude to luminosity conversion. Default is
-        None.
 
     Returns
     -------
     luminosity : array_like
-        Drawn luminosities from the Schechter luminosity function. If a filter
-        band is given, the luminosity is returned in units of solar luminosity.
+        Drawn luminosities from the Schechter luminosity function. Luminosities
+        are B-band luminosities in units of solar luminosity.
 
     Notes
     -----
@@ -107,13 +104,16 @@ def herbel_luminosities(redshift, alpha, a_m, b_m, size=None,
     if size is None and np.shape(redshift):
         size = np.shape(redshift)
 
-    luminosity_star = _calculate_luminosity_star(redshift, a_m, b_m, band)
+    # this is the AB zeropoint of the B-band in units of solar luminosity
+    zeropt = -4.73
+
+    luminosity_star = _calculate_luminosity_star(redshift, a_m, b_m, zeropt)
 
     x_sample = schechter(alpha, x_min, x_max, resolution=resolution, size=size)
 
     return luminosity_star * x_sample
 
 
-def _calculate_luminosity_star(redshift, a_m, b_m, band=None):
+def _calculate_luminosity_star(redshift, a_m, b_m, zeropoint=None):
     absolute_magnitude_star = a_m * redshift + b_m
-    return astro.luminosity_from_absolute_magnitude(absolute_magnitude_star, band)
+    return astro.luminosity_from_absolute_magnitude(absolute_magnitude_star, zeropoint)

--- a/skypy/galaxy/luminosity.py
+++ b/skypy/galaxy/luminosity.py
@@ -15,7 +15,7 @@ __all__ = [
 
 def herbel_luminosities(redshift, alpha, a_m, b_m, size=None,
                         x_min=0.00305,
-                        x_max=1100.0, resolution=100):
+                        x_max=1100.0, resolution=100, band=None):
 
     r"""Model of Herbel et al (2017)
 
@@ -40,11 +40,15 @@ def herbel_luminosities(redshift, alpha, a_m, b_m, size=None,
         Lower and upper luminosity bounds in units of L*.
     resolution : int, optional
         Resolution of the inverse transform sampling spline. Default is 100.
+    band : str, optional
+        Filter band for absolute magnitude to luminosity conversion. Default is
+        None.
 
     Returns
     -------
     luminosity : array_like
-        Drawn luminosities from the Schechter luminosity function.
+        Drawn luminosities from the Schechter luminosity function. If a filter
+        band is given, the luminosity is returned in units of solar luminosity.
 
     Notes
     -----
@@ -98,20 +102,18 @@ def herbel_luminosities(redshift, alpha, a_m, b_m, size=None,
     >>> luminosities = lum.herbel_luminosities(z, -1.3, -0.9408582,
     ...                                         -20.40492365)
 
-
-
     """
 
     if size is None and np.shape(redshift):
         size = np.shape(redshift)
 
-    luminosity_star = _calculate_luminosity_star(redshift, a_m, b_m)
+    luminosity_star = _calculate_luminosity_star(redshift, a_m, b_m, band)
 
     x_sample = schechter(alpha, x_min, x_max, resolution=resolution, size=size)
 
     return luminosity_star * x_sample
 
 
-def _calculate_luminosity_star(redshift, a_m, b_m):
+def _calculate_luminosity_star(redshift, a_m, b_m, band=None):
     absolute_magnitude_star = a_m * redshift + b_m
-    return astro.luminosity_from_absolute_magnitude(absolute_magnitude_star)
+    return astro.luminosity_from_absolute_magnitude(absolute_magnitude_star, band)

--- a/skypy/galaxy/tests/test_luminosity.py
+++ b/skypy/galaxy/tests/test_luminosity.py
@@ -29,14 +29,15 @@ def test_herbel_luminosities():
     # Test that sampling corresponds to sampling from the right pdf.
     # For this, we sample an array of luminosities for redshift z = 1.0 and we
     # compare it to the corresponding cdf.
+    # The B-band zeropoint for the model is -4.73.
 
     def calc_pdf(luminosity, z, alpha, a_m, b_m, absolute_magnitude_max=-16.0,
                  absolute_magnitude_min=-28.0):
         luminosity_min = astro.luminosity_from_absolute_magnitude(
-            absolute_magnitude_max)
+            absolute_magnitude_max, -4.73)
         luminosity_max = astro.luminosity_from_absolute_magnitude(
-            absolute_magnitude_min)
-        lum_star = lum._calculate_luminosity_star(z, a_m, b_m)
+            absolute_magnitude_min, -4.73)
+        lum_star = lum._calculate_luminosity_star(z, a_m, b_m, -4.73)
         c = np.fabs(special.gammaincc(alpha+1, luminosity_min/lum_star))
         d = np.fabs(special.gammaincc(alpha+1, luminosity_max/lum_star))
         return 1./lum_star*np.power(luminosity/lum_star, alpha)*np.exp(
@@ -59,8 +60,9 @@ def test_herbel_luminosities():
 
 def test_exponential_distribution():
     # When alpha=0, L*=1 and x_min~0 we get a truncated exponential
+    # the b_m value offsets the B-band zeropoint of -4.73
     q_max = 1e2
-    sample = lum.herbel_luminosities(0, 0, 0, 0, size=1000,
+    sample = lum.herbel_luminosities(0, 0, 0, 4.73, size=1000,
                                      x_min=1e-10, x_max=q_max,
                                      resolution=1000)
     d, p_value = scipy.stats.kstest(sample, 'truncexpon', args=(q_max,))

--- a/skypy/galaxy/tests/test_redshift.py
+++ b/skypy/galaxy/tests/test_redshift.py
@@ -80,7 +80,7 @@ def test_herbel_pdf():
     pdf = herbel_pdf(np.array([0.01, 0.5, 1, 2]),
                      -0.5, -0.70596888,
                      0.0035097, -0.70798041,
-                     -20.37196157, cosmology, np.power(10, -0.4 * -16.0))
+                     -20.37196157, cosmology, -16.0)
     result = np.array(
         [4.09063927e+04, 4.45083420e+07, 7.26629445e+07, 5.40766813e+07])
     np.testing.assert_allclose(pdf, result)
@@ -121,7 +121,7 @@ def test_herbel_redshift_sampling():
                          b_phi=0.00370253,
                          b_m=-20.40492365,
                          cosmology=cosmology,
-                         luminosity_min=2511886.4315095823)
+                         absolute_magnitude_max=-16)
         cdf = scipy.integrate.cumtrapz(pdf, z, initial=0)
         cdf = cdf / cdf[-1]
         return cdf

--- a/skypy/utils/astronomy.py
+++ b/skypy/utils/astronomy.py
@@ -19,11 +19,11 @@ import numpy as np
 
 
 # absolute AB magnitude in various bands in terms of solar luminosity
-# values depend on exact definition of bandpass and are approximate
+# values depend on the particular bandpass used and are approximate
 standard_bandpass_zeropoints = {
-    'U': -3.20,
-    'B': -3.11,
-    'V': -2.51,
+    'U': -4.98,
+    'B': -4.73,
+    'V': -4.48,
 }
 
 

--- a/skypy/utils/astronomy.py
+++ b/skypy/utils/astronomy.py
@@ -18,58 +18,45 @@ Utility functions
 import numpy as np
 
 
-# absolute AB magnitude in various bands in terms of solar luminosity
-# values depend on the particular bandpass used and are approximate
-standard_bandpass_zeropoints = {
-    'U': -4.98,
-    'B': -4.73,
-    'V': -4.48,
-}
-
-
-def luminosity_from_absolute_magnitude(absolute_magnitude, band=None):
+def luminosity_from_absolute_magnitude(absolute_magnitude, zeropoint=None):
     """ Converts absolute magnitudes into luminosities
 
     Parameters
     ----------
     absolute_magnitude : array_like
         Input absolute magnitudes
-    band : str, optional
-        Standard bandpass for conversion.
+    zeropoint : float, optional
+        Zeropoint for the conversion.
 
     Returns
     -------
     ndarray, or float if input is scalar
-    Luminosity values. If a standard bandpass is given, the luminosity is in
-    units of solar luminosity.
+    Luminosity values.
     """
 
-    zeropoint = 0
-    if band is not None:
-        zeropoint = standard_bandpass_zeropoints[band]
+    if zeropoint is None:
+        zeropoint = 0.
 
     return 10.**(-0.4*np.add(absolute_magnitude, zeropoint))
 
 
-def absolute_magnitude_from_luminosity(luminosity, band=None):
+def absolute_magnitude_from_luminosity(luminosity, zeropoint=None):
     """ Converts luminosities into absolute magnitudes
 
     Parameters
     ----------
     luminosity : array_like
         Input luminosity
-    band : str, optional
-        Standard bandpass for conversion.
+    zeropoint : float, optional
+        Zeropoint for the conversion.
 
     Returns
     -------
     ndarray, or float if input is scalar
-    Absolute magnitude values. If a standard bandpass is given, the luminosity
-    is assumed in units of solar luminosity.
+    Absolute magnitude values.
     """
 
-    zeropoint = 0
-    if band is not None:
-        zeropoint = standard_bandpass_zeropoints[band]
+    if zeropoint is None:
+        zeropoint = 0.
 
     return -2.5*np.log10(luminosity) - zeropoint

--- a/skypy/utils/astronomy.py
+++ b/skypy/utils/astronomy.py
@@ -18,33 +18,58 @@ Utility functions
 import numpy as np
 
 
-def luminosity_from_absolute_magnitude(absolute_magnitude):
+# absolute AB magnitude in various bands in terms of solar luminosity
+# values depend on exact definition of bandpass and are approximate
+standard_bandpass_zeropoints = {
+    'U': -3.20,
+    'B': -3.11,
+    'V': -2.51,
+}
+
+
+def luminosity_from_absolute_magnitude(absolute_magnitude, band=None):
     """ Converts absolute magnitudes into luminosities
 
     Parameters
     ----------
     absolute_magnitude : array_like
-                    Input absolute magnitudes
+        Input absolute magnitudes
+    band : str, optional
+        Standard bandpass for conversion.
+
     Returns
     -------
     ndarray, or float if input is scalar
-    Luminosity values.
+    Luminosity values. If a standard bandpass is given, the luminosity is in
+    units of solar luminosity.
     """
 
-    return np.power(10, -0.4*absolute_magnitude)
+    zeropoint = 0
+    if band is not None:
+        zeropoint = standard_bandpass_zeropoints[band]
+
+    return 10.**(-0.4*np.add(absolute_magnitude, zeropoint))
 
 
-def absolute_magnitude_from_luminosity(luminosity):
+def absolute_magnitude_from_luminosity(luminosity, band=None):
     """ Converts luminosities into absolute magnitudes
 
     Parameters
     ----------
     luminosity : array_like
-            Input luminosity
+        Input luminosity
+    band : str, optional
+        Standard bandpass for conversion.
 
     Returns
     -------
     ndarray, or float if input is scalar
-    Absolute magnitude values
+    Absolute magnitude values. If a standard bandpass is given, the luminosity
+    is assumed in units of solar luminosity.
     """
-    return -np.log(luminosity)/(0.4 * np.log(10))
+
+    zeropoint = 0
+    if band is not None:
+        zeropoint = standard_bandpass_zeropoints[band]
+
+    return -2.5*np.log10(luminosity) - zeropoint


### PR DESCRIPTION
## Description

Adds an optional `band` parameter to functions working with absolute magnitudes and luminosities. If a standard filter band is given, luminosities are returned in units of solar luminosity for that band.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request