### PR TITLE
Sersic indices for red and blue galaxies

### DIFF
--- a/examples/herbel_galaxies.yaml
+++ b/examples/herbel_galaxies.yaml
@@ -4,6 +4,8 @@ cosmology:
   kwargs:
     H0: 67.7
     Om0: 0.307
+red_galaxy_sersic_index: 4
+blue_galaxy_sersic_index: 1
 tables:
   red_galaxies:
     redshift:


### PR DESCRIPTION
## Description
Add fixed sersic indices for red and blue galaxies to the Herbel galaxies example. Resolves #28 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
