### PR TITLE
Hide random outputs in halo_mass_sampler doctest

### DIFF
--- a/skypy/halo/mass.py
+++ b/skypy/halo/mass.py
@@ -178,20 +178,17 @@ def halo_mass_sampler(m_min, m_max, resolution, wavenumber, power_spectrum,
 
     Sampling from the Sheth and Tormen mass function:
 
-    >>> mass.sheth_tormen(10**9, 10**12, 100, k, Pk, D0, cosmo)
-    29585260719.18...
+    >>> halo_mass = mass.sheth_tormen(1e9, 1e12, 100, k, Pk, D0, cosmo)
 
     And from the Press-Schechter mass function:
 
-    >>> mass.press_schechter(10**9, 10**12, 100, k, Pk, D0, cosmo)
-    29281420133.34...
+    >>> halo_mass = mass.press_schechter(1e9, 1e12, 100, k, Pk, D0, cosmo)
 
     For any other collapse models:
 
     >>> params_model = (0.3, 0.7, 0.3, 1.686)
-    >>> mass.halo_mass_sampler(10**9, 10**12, 100, k, Pk, D0, cosmo,
+    >>> halo_mass = mass.halo_mass_sampler(1e9, 1e12, 100, k, Pk, D0, cosmo,
     ...     ellipsoidal_collapse_function, params=params_model)
-    1504984926.64...
 
     References
     ----------


### PR DESCRIPTION
## Description
The halo_mass_sampler doctests require the RNG seed to be fixed so that the same samples are generated every time. However other doctests can modify the RNG seed causing different values to be generated so the tests fail. Hide the outputs of the halo_mass_sampler doctests to prevent this type of failure.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
