### PR TITLE
Mock camb on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,5 @@ python:
       path: .
       extra_requirements:
         - docs
-        - all
 
 formats: []

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -238,3 +238,10 @@ plot_rcparams = {
     'figure.subplot.wspace': 0.4,
     'text.usetex': False,
 }
+
+# Mock camb if it is not available e.g. on readthedocs
+autodoc_mock_imports = []
+try:
+    import_module('camb')
+except ImportError:
+    autodoc_mock_imports.append('camb')


### PR DESCRIPTION
## Description
Camb cannot be built on readthedocs because there is no fortran compiler. Instead do not try to build camb and mock it when building the docs. Resolves #220 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Assign someone from your working team to review this pull request
