### PR TITLE
Remove related_identifiers from zenodo config

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -123,12 +123,5 @@
             "type": "ProjectMember"
         }
     ],
-    "access_right": "open",
-    "related_identifiers": [
-        {
-            "scheme": "doi",
-            "identifier": "10.5281/zenodo.3755531",
-            "relation": "isVersionOf"
-        }
-    ]
+    "access_right": "open"
 }


### PR DESCRIPTION
## Description
The `related_identifiers` field in the zenodo config file is probably the cause of an error when creating a new version. See https://github.com/zenodo/zenodo/issues/1667 for a similar case. Removing that field from our config file.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Assign someone from the infrastructure team to review this pull request
