### PR TITLE
config and overwrite command line arguments for driver script

### DIFF
--- a/skypy/pipeline/driver.py
+++ b/skypy/pipeline/driver.py
@@ -22,7 +22,7 @@ class SkyPyDriver:
     and using their results to generate variables and tables.
     '''
 
-    def execute(self, configuration, file_format=None):
+    def execute(self, configuration, file_format=None, overwrite=False):
         r'''Run a pipeline.
 
         This function runs a pipeline of functions to generate variables and
@@ -38,6 +38,8 @@ class SkyPyDriver:
             File format used to write tables. Files are written using the
             Astropy unified file read/write interface; see [2]_ for supported
             file formats. If None (default) tables are not written to file.
+        overwrite : bool
+            Whether to overwrite any existing files without warning.
 
         Notes
         -----
@@ -131,7 +133,7 @@ class SkyPyDriver:
         if file_format:
             for table in table_config.keys():
                 filename = '.'.join((table, file_format))
-                getattr(self, table).write(filename)
+                getattr(self, table).write(filename, overwrite=overwrite)
 
     def _call_from_config(self, config):
 

--- a/skypy/pipeline/scripts/skypy.py
+++ b/skypy/pipeline/scripts/skypy.py
@@ -48,8 +48,8 @@ def main(args=None):
                         type=argparse.FileType('r'), help='Config file name')
     parser.add_argument('-f', '--format', required=False,
                         choices=['fits', 'hdf5'], help='Table file format')
-    parser.add_argument('-o', '--overwrite', default=False,
-                        type=bool, help='Whether to overwrite existing files')
+    parser.add_argument('-o', '--overwrite', action='store_true',
+                        help='Whether to overwrite existing files')
 
     # get system args if none passed
     if args is None:

--- a/skypy/pipeline/scripts/skypy.py
+++ b/skypy/pipeline/scripts/skypy.py
@@ -48,6 +48,8 @@ def main(args=None):
                         type=argparse.FileType('r'), help='Config file name')
     parser.add_argument('-f', '--format', required=False,
                         choices=['fits', 'hdf5'], help='Table file format')
+    parser.add_argument('-o', '--overwrite', default=False,
+                        type=bool, help='Whether to overwrite existing files')
 
     # get system args if none passed
     if args is None:
@@ -57,5 +59,5 @@ def main(args=None):
     config = yaml.safe_load(args.config)
     config = {} if config is None else config
     driver = SkyPyDriver()
-    driver.execute(config, file_format=args.format)
+    driver.execute(config, file_format=args.format, overwrite=args.overwrite)
     return(0)

--- a/skypy/pipeline/scripts/skypy.py
+++ b/skypy/pipeline/scripts/skypy.py
@@ -44,8 +44,8 @@ def main(args=None):
     import yaml
 
     parser = argparse.ArgumentParser(description="SkyPy pipeline driver")
-    parser.add_argument('-c', '--config', required=True,
-                        type=argparse.FileType('r'), help='Config file name')
+    parser.add_argument('config', type=argparse.FileType('r'),
+                        help='Config file name')
     parser.add_argument('-f', '--format', required=False,
                         choices=['fits', 'hdf5'], help='Table file format')
     parser.add_argument('-o', '--overwrite', action='store_true',

--- a/skypy/pipeline/tests/test_driver.py
+++ b/skypy/pipeline/tests/test_driver.py
@@ -41,6 +41,17 @@ def test_driver():
     with fits.open('test_table.fits') as hdu:
         assert np.all(Table(hdu[1].data) == driver.test_table)
 
+    # Check for failure if output files already exist and overwrite is False
+    driver = SkyPyDriver()
+    with pytest.raises(OSError):
+        driver.execute(config, file_format='fits', overwrite=False)
+
+    # Check that the existing output files are modified if overwrite is True
+    timestamp = os.path.getmtime("test_table.fits")
+    driver = SkyPyDriver()
+    driver.execute(config, file_format='fits', overwrite=True)
+    assert(os.path.getmtime("test_table.fits") > timestamp)
+
     # Check for failure if 'column1' requires itself creating a cyclic
     # dependency graph
     config['tables']['test_table']['column1']['requires'] = \

--- a/skypy/pipeline/tests/test_skypy.py
+++ b/skypy/pipeline/tests/test_skypy.py
@@ -15,20 +15,20 @@ def test_skypy():
         skypy.main(['--help'])
     assert e.value.code == 0
 
-    # Missing required argument '-c'
+    # Missing positional argument 'config'
     with pytest.raises(SystemExit) as e:
         skypy.main(['--format', 'fits'])
     assert e.value.code == 2
 
     # Invalid file format
     with pytest.raises(SystemExit) as e:
-        skypy.main(['--config', 'config.filename', '--format', 'invalid'])
+        skypy.main(['--format', 'invalid', 'config.filename'])
     assert e.value.code == 2
 
     # Process empty config file
     filename = get_pkg_data_filename('data/empty_config.yml')
-    assert skypy.main(['--config', filename]) == 0
+    assert skypy.main([filename]) == 0
 
     # Process test config file
     filename = get_pkg_data_filename('data/test_config.yml')
-    assert skypy.main(['--config', filename]) == 0
+    assert skypy.main([filename]) == 0


### PR DESCRIPTION
## Description
- Make `config` a positional argument instead of a required argument
- Add `-o/--overwrite` command line flag to `skypy` script to overwrite any existing files with the same names as the output files without warning. Resolves #232 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from the infrastructure team to review this pull request
