### PR TITLE
make growth_function accept any redshift shape

### DIFF
--- a/skypy/power_spectrum/_growth.py
+++ b/skypy/power_spectrum/_growth.py
@@ -127,9 +127,11 @@ def growth_function(redshift, cosmology, gamma=6.0/11.0, z_upper=1100):
     cosmology : astropy.cosmology.Cosmology
         Cosmology object providing methods for the evolution history of
         omega_matter and omega_lambda with redshift.
-    gamma : float
+    gamma : float, optional
         Growth index providing an efficient parametrization of the matter
-        perturbations.
+        perturbations. Default is the 6/11 LCDM value.
+    z_upper : float, optional
+        Redshift for to early-time integral cutoff. Default is 1100.
 
     Returns
     -------

--- a/skypy/power_spectrum/_growth.py
+++ b/skypy/power_spectrum/_growth.py
@@ -164,9 +164,8 @@ def growth_function(redshift, cosmology, gamma=6.0/11.0):
 
     for i, zz in enumerate(z_flat):
         integral = integrate.quad(integrand, zz, 1100)[0]
-        growth_function[i] = np.exp(integral)
-
-    growth_function /= 1 + z_flat
+        g = np.exp(integral)
+        growth_function[i] = g / (1 + zz)
 
     if np.ndim(z) == 0:
         growth_function = growth_function.item()

--- a/skypy/power_spectrum/_growth.py
+++ b/skypy/power_spectrum/_growth.py
@@ -114,7 +114,7 @@ def growth_factor(redshift, cosmology, gamma=6.0/11.0):
     return growth_factor
 
 
-def growth_function(redshift, cosmology, gamma=6.0/11.0):
+def growth_function(redshift, cosmology, gamma=6.0/11.0, z_upper=1100):
     r'''Growth function.
 
     Function used to calculate :math:`D(z)`, growth function at different
@@ -153,7 +153,6 @@ def growth_function(redshift, cosmology, gamma=6.0/11.0):
     ----------
     .. [1] E. V. Linder, Phys. Rev. D 72, 043529 (2005)
     '''
-    z = redshift
 
     def integrand(x):
         integrand = (growth_factor(x, cosmology, gamma) - 1) / (1 + x)
@@ -163,14 +162,14 @@ def growth_function(redshift, cosmology, gamma=6.0/11.0):
     g_flat = np.empty(z_flat.size)
 
     for i, z in enumerate(z_flat):
-        integral = integrate.quad(integrand, zz, z_upper)[0]
+        integral = integrate.quad(integrand, z, z_upper)[0]
         g = np.exp(integral)
-        g_flat[i] = g / (1 + zz)
+        g_flat[i] = g / (1 + z)
 
-    if np.isscalar(z):
+    if np.isscalar(redshift):
         growth_function = g_flat.item()
     else:
-        growth_function = g_flat.reshape(np.shape(z))
+        growth_function = g_flat.reshape(np.shape(redshift))
 
     return growth_function
 

--- a/skypy/power_spectrum/_growth.py
+++ b/skypy/power_spectrum/_growth.py
@@ -160,17 +160,17 @@ def growth_function(redshift, cosmology, gamma=6.0/11.0):
         return integrand
 
     z_flat = np.ravel(z)
-    growth_function = np.empty_like(z_flat)
+    g_flat = np.empty(z_flat.size)
 
     for i, zz in enumerate(z_flat):
         integral = integrate.quad(integrand, zz, 1100)[0]
         g = np.exp(integral)
-        growth_function[i] = g / (1 + zz)
+        g_flat[i] = g / (1 + zz)
 
-    if np.ndim(z) == 0:
-        growth_function = growth_function.item()
+    if np.isscalar(z):
+        growth_function = g_flat.item()
     else:
-        growth_function = growth_function.reshape(np.shape(z))
+        growth_function = g_flat.reshape(np.shape(z))
 
     return growth_function
 

--- a/skypy/power_spectrum/_growth.py
+++ b/skypy/power_spectrum/_growth.py
@@ -159,21 +159,19 @@ def growth_function(redshift, cosmology, gamma=6.0/11.0):
         integrand = (growth_factor(x, cosmology, gamma) - 1) / (1 + x)
         return integrand
 
-    if isinstance(z, int) or isinstance(z, float):
-        integral = integrate.quad(integrand, z, 1100)[0]
-        g = np.exp(integral)
-        growth_function = g / (1 + z)
+    z_flat = np.ravel(z)
+    growth_function = np.empty_like(z_flat)
 
-    elif isinstance(z, np.ndarray):
-        growth_function = np.zeros(np.shape(z))
+    for i, zz in enumerate(z_flat):
+        integral = integrate.quad(integrand, zz, 1100)[0]
+        growth_function[i] = np.exp(integral)
 
-        for i, aux in enumerate(z):
-            integral = integrate.quad(integrand, aux, 1100)[0]
-            g = np.exp(integral)
-            growth_function[i] = g / (1 + aux)
+    growth_function /= 1 + z_flat
 
+    if np.ndim(z) == 0:
+        growth_function = growth_function.item()
     else:
-        raise ValueError('Redshift must be integer, float or ndarray ')
+        growth_function = growth_function.reshape(np.shape(z))
 
     return growth_function
 

--- a/skypy/power_spectrum/_growth.py
+++ b/skypy/power_spectrum/_growth.py
@@ -131,7 +131,7 @@ def growth_function(redshift, cosmology, gamma=6.0/11.0, z_upper=1100):
         Growth index providing an efficient parametrization of the matter
         perturbations. Default is the 6/11 LCDM value.
     z_upper : float, optional
-        Redshift for to early-time integral cutoff. Default is 1100.
+        Redshift for the early-time integral cutoff. Default is 1100.
 
     Returns
     -------

--- a/skypy/power_spectrum/_growth.py
+++ b/skypy/power_spectrum/_growth.py
@@ -159,11 +159,11 @@ def growth_function(redshift, cosmology, gamma=6.0/11.0):
         integrand = (growth_factor(x, cosmology, gamma) - 1) / (1 + x)
         return integrand
 
-    z_flat = np.ravel(z)
+    z_flat = np.ravel(redshift)
     g_flat = np.empty(z_flat.size)
 
-    for i, zz in enumerate(z_flat):
-        integral = integrate.quad(integrand, zz, 1100)[0]
+    for i, z in enumerate(z_flat):
+        integral = integrate.quad(integrand, zz, z_upper)[0]
         g = np.exp(integral)
         g_flat[i] = g / (1 + zz)
 

--- a/skypy/power_spectrum/tests/test_growth.py
+++ b/skypy/power_spectrum/tests/test_growth.py
@@ -68,6 +68,11 @@ def test_growth():
     assert allclose(Dz, 1. / (1. + redshift)),\
         "Growth function is not close to the scale factor"
 
+    # make sure that growth_function with scalar returns scalar
+    Dz2 = growth_function(redshift[2], cosmology_flat)
+    assert np.isscalar(Dz2), 'growth function with scalar did not produce scalar'
+    assert Dz2 == Dz[2], 'growth function with scalar produced inconsistent result'
+
     # Test growth function derivative
     assert redshift.shape == Dzprime.shape,\
         "Length of redshift array and growth function array do not match"


### PR DESCRIPTION
## Description

This PR makes `skypy.power_spectrum.growth_function` accepts redshift arrays of arbitrary shape.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
