### PR TITLE
refactor Schechter luminosity function sampling

### DIFF
--- a/docs/galaxy.rst
+++ b/docs/galaxy.rst
@@ -36,7 +36,7 @@ The following models are found in the `skypy.galaxy.luminosity` package.
 .. autosummary::
    :nosignatures:
 
-   herbel_luminosities
+   schechter_lf_magnitude
 
 
 Redshift
@@ -48,7 +48,8 @@ The following models are found in the `skypy.galaxy.redshift` package.
 .. autosummary::
    :nosignatures:
 
-   herbel_redshift
+   redshifts_from_comoving_density
+   schechter_lf_redshift
    smail
 
 

--- a/examples/abundance_matching.yml
+++ b/examples/abundance_matching.yml
@@ -2,6 +2,7 @@ cosmology: !astropy.cosmology.default_cosmology.get
 A_s: 2.1982e-09
 n_s: 0.969453
 redshift: 1
+M_star: !astropy.modeling.models.Linear1D [-0.70798041, -20.37196157]
 growth_function: !skypy.power_spectrum.growth_function
   redshift: $redshift
   cosmology: $cosmology
@@ -23,12 +24,14 @@ tables:
       growth_function: $growth_function
       cosmology: $cosmology
   galaxies:
-    luminosity: !skypy.galaxy.luminosity.herbel_luminosities
-      alpha: -0.5
-      a_m: -0.610
-      b_m: -20.416
-      size: 100
+    magnitude: !skypy.galaxy.luminosity.schechter_lf_magnitude
       redshift: $redshift
+      M_star: $M_star
+      alpha: -0.5
+      m_lim: 35
+      size: 100
+    luminosity: !skypy.utils.astronomy.luminosity_from_absolute_magnitude
+      absolute_magnitude: $galaxies.magnitude
   abundance_matching:
     .init: !skypy.halo.abundance_matching.vale_ostriker
       .depends: [halos.complete, galaxies.complete]

--- a/examples/gravitational_wave_rates.yml
+++ b/examples/gravitational_wave_rates.yml
@@ -1,19 +1,29 @@
 cosmology: !astropy.cosmology.default_cosmology.get
+z_range: !numpy.arange [0, 2.01, 0.1]
+mag_lim: 30
+fsky: 0.0000242407
+M_star_red: !astropy.modeling.models.Linear1D [-0.70798041, -20.37196157]
+phi_star_red: !astropy.modeling.models.Exponential1D [0.0035097, -1.41649]
+alpha_red: -0.5
+M_star_blue: !astropy.modeling.models.Linear1D [-0.9408582, -20.40492365]
+phi_star_blue: !astropy.modeling.models.Exponential1D [0.00370253, -9.73858]
+alpha_blue: -1.3
 tables:
   merger_rates:
-    redshift: !skypy.galaxy.redshift.herbel_redshift
-      alpha: -0.5
-      a_phi: -2.232
-      b_phi: 0.0141
-      a_m: -0.610
-      b_m: -20.416
-      size: 1000
-      cosmology: $cosmology
-    luminosity: !skypy.galaxy.luminosity.herbel_luminosities
-      alpha: -0.5
-      a_m: -0.610
-      b_m: -20.416
+    redshift: !skypy.galaxy.redshift.schechter_lf_redshift
+      redshift: $z_range
+      M_star: $M_star_red
+      phi_star: $phi_star_red
+      alpha: $alpha_red
+      m_lim: $mag_lim
+      fsky: $fsky
+    magnitude: !skypy.galaxy.luminosity.schechter_lf_magnitude
       redshift: $merger_rates.redshift
+      M_star: $M_star_red
+      alpha: $alpha_red
+      m_lim: $mag_lim
+    luminosity: !skypy.utils.astronomy.luminosity_from_absolute_magnitude
+      absolute_magnitude: $merger_rates.magnitude
     ns_ns_rate: !skypy.gravitational_wave.b_band_merger_rate
       population: NS-NS
       optimism: low

--- a/examples/mccl_galaxies.yml
+++ b/examples/mccl_galaxies.yml
@@ -1,26 +1,31 @@
 cosmology: !astropy.cosmology.FlatLambdaCDM
   H0: 67.7
   Om0: 0.307
+z_range: !numpy.arange [0, 2.01, 0.1]
+mag_lim: 30
+fsky: 0.0000242407
+M_star_red: !astropy.modeling.models.Linear1D [-0.70798041, -20.37196157]
+phi_star_red: !astropy.modeling.models.Exponential1D [0.0035097, -1.41649]
+alpha_red: -0.5
+M_star_blue: !astropy.modeling.models.Linear1D [-0.9408582, -20.40492365]
+phi_star_blue: !astropy.modeling.models.Exponential1D [0.00370253, -9.73858]
+alpha_blue: -1.3
 red_galaxy_sersic_index: 4
 blue_galaxy_sersic_index: 1
 tables:
   red_galaxies:
-    redshift: !skypy.galaxy.redshift.herbel_redshift
-      alpha: -0.5
-      a_phi: -2.232
-      b_phi: 0.0141
-      a_m: -0.610
-      b_m: -20.416
-      size: 141
-      cosmology: $cosmology
-    luminosity: !skypy.galaxy.luminosity.herbel_luminosities
-      alpha: -0.5
-      a_m: -0.610
-      b_m: -20.416
+    redshift: !skypy.galaxy.redshift.schechter_lf_redshift
+      redshift: $z_range
+      M_star: $M_star_red
+      phi_star: $phi_star_red
+      alpha: $alpha_red
+      m_lim: $mag_lim
+      fsky: $fsky
+    magnitude: !skypy.galaxy.luminosity.schechter_lf_magnitude
       redshift: $red_galaxies.redshift
-    magnitude: !skypy.utils.astronomy.absolute_magnitude_from_luminosity
-      luminosity: $red_galaxies.luminosity
-      zeropoint: -4.73
+      M_star: $M_star_red
+      alpha: $alpha_red
+      m_lim: $mag_lim
     spectral_coefficients: !skypy.galaxy.spectrum.dirichlet_coefficients
       alpha0: [2.461, 2.358, 2.568, 2.268, 2.402]
       alpha1: [2.410, 2.340, 2.200, 2.540, 2.464]
@@ -40,24 +45,20 @@ tables:
     ellipticity: !skypy.galaxy.ellipticity.beta_ellipticity
       e_ratio: 0.45
       e_sum: 3.5
-      size: 141
+      size: !len [$red_galaxies.redshift]
   blue_galaxies:
-    redshift: !skypy.galaxy.redshift.herbel_redshift
-      alpha: -1.3
-      a_phi: -0.264
-      b_phi: 0.0063
-      a_m: -0.417
-      b_m: -20.591
-      size: 63
-      cosmology: $cosmology
-    luminosity: !skypy.galaxy.luminosity.herbel_luminosities
-      alpha: -1.3
-      a_m: -0.417
-      b_m: -20.591
+    redshift: !skypy.galaxy.redshift.schechter_lf_redshift
+      redshift: $z_range
+      M_star: $M_star_blue
+      phi_star: $phi_star_blue
+      alpha: $alpha_blue
+      m_lim: $mag_lim
+      fsky: $fsky
+    magnitude: !skypy.galaxy.luminosity.schechter_lf_magnitude
       redshift: $blue_galaxies.redshift
-    magnitude: !skypy.utils.astronomy.absolute_magnitude_from_luminosity
-      luminosity: $blue_galaxies.luminosity
-      zeropoint: -4.73
+      M_star: $M_star_blue
+      alpha: $alpha_blue
+      m_lim: $mag_lim
     spectral_coefficients: !skypy.galaxy.spectrum.dirichlet_coefficients
       alpha0: [2.079, 3.524, 1.917, 1.992, 2.536]
       alpha1: [2.265, 3.862, 1.921, 1.685, 2.480]
@@ -78,4 +79,4 @@ tables:
     ellipticity: !skypy.galaxy.ellipticity.beta_ellipticity
       e_ratio: 0.45
       e_sum: 3.5
-      size: 63
+      size: !len [$blue_galaxies.redshift]

--- a/skypy/galaxy/__init__.py
+++ b/skypy/galaxy/__init__.py
@@ -3,9 +3,15 @@ This module contains methods that model the intrinsic properties of galaxy
 populations.
 """
 
+__all__ = [
+    'schechter_lf',
+]
+
 from . import ellipticity  # noqa F401,F403
 from . import luminosity  # noqa F401,F403
 from . import redshift  # noqa F401,F403
 from . import size  # noqa F401,F403
 from . import spectrum  # noqa F401,F403
 from . import stellar_mass  # noqa F401,F403
+
+from ._schechter import schechter_lf  # noqa

--- a/skypy/galaxy/_schechter.py
+++ b/skypy/galaxy/_schechter.py
@@ -1,0 +1,77 @@
+'''Implementation of Schechter LF and SMF.'''
+
+import numpy as np
+
+from ..utils import uses_default_cosmology
+from .redshift import schechter_lf_redshift
+from .luminosity import schechter_lf_magnitude
+
+
+__all__ = [
+    'schechter_lf',
+]
+
+
+@uses_default_cosmology
+def schechter_lf(redshift, M_star, phi_star, alpha, m_lim, fsky, cosmology, noise=True):
+    r'''Sample redshifts and magnitudes from a Schechter luminosity function.
+
+    Sample the redshifts and magnitudes of galaxies following a Schechter
+    luminosity function with potentially redshift-dependent parameters, limited
+    by an apparent magnitude `m_lim`, for a fraction `fsky` of the sky.
+
+    Parameters
+    ----------
+    redshift : array_like
+        Input redshift grid on which the Schechter function parameters are
+        evaluated. Galaxies are sampled over this redshift range.
+    M_star : array_like or function
+        Characteristic absolute magnitude of the Schechter function. Can be a
+        single value, an array of values for each `redshift`, or a function of
+        redshift.
+    phi_star : array_like or function
+        Normalisation of the Schechter function. Can be a single value, an
+        array of values for each `redshift`, or a function of redshift.
+    alpha : array_like or function
+        Schechter function power law index. Can be a single value, an array of
+        values for each `redshift`, or a function of redshift.
+    m_lim : float
+        Limiting apparent magnitude.
+    fsky : array_like
+        Sky fraction over which galaxies are sampled.
+    cosmology : Cosmology, optional
+        Cosmology object to convert apparent to absolute magnitudes. If not
+        given, the default cosmology is used.
+    noise : bool, optional
+        Poisson-sample the number of galaxies. Default is `True`.
+
+    Notes
+    -----
+
+    Effectively calls `~skypy.galaxy.redshift.schechter_lf_redshift` and
+    `~skypy.galaxy.luminosity.schechter_lf_magnitude` internally and returns
+    the tuple of results.
+
+    Returns
+    -------
+    redshifts, magnitudes : tuple of array_like
+        Redshifts and magnitudes of the galaxy sample described by the Schechter
+        luminosity function.
+
+    '''
+
+    # sample galaxy redshifts
+    z = schechter_lf_redshift(redshift, M_star, phi_star, alpha, m_lim, fsky, cosmology, noise)
+
+    # if a function is NOT given for M_star, phi_star, alpha, interpolate to z
+    if not callable(M_star) and np.ndim(M_star) > 0:
+        M_star = np.interp(z, redshift, M_star)
+    if not callable(phi_star) and np.ndim(phi_star) > 0:
+        phi_star = np.interp(z, redshift, phi_star)
+    if not callable(alpha) and np.ndim(alpha) > 0:
+        alpha = np.interp(z, redshift, alpha)
+
+    # sample galaxy magnitudes for redshifts
+    M = schechter_lf_magnitude(z, M_star, alpha, m_lim, cosmology)
+
+    return z, M

--- a/skypy/galaxy/luminosity.py
+++ b/skypy/galaxy/luminosity.py
@@ -4,116 +4,81 @@ r"""Models of galaxy luminosities.
 
 import numpy as np
 
-import skypy.utils.astronomy as astro
-from skypy.utils.random import schechter
+from ..utils.random import schechter
+from ..utils import uses_default_cosmology, dependent_argument
 
 
 __all__ = [
-    'herbel_luminosities',
+    'schechter_lf_magnitude',
 ]
 
 
-def herbel_luminosities(redshift, alpha, a_m, b_m, size=None,
-                        x_min=0.00305,
-                        x_max=1100.0, resolution=100):
+@uses_default_cosmology
+@dependent_argument('M_star', 'redshift')
+@dependent_argument('alpha', 'redshift')
+def schechter_lf_magnitude(redshift, M_star, alpha, m_lim, cosmology, size=None,
+                           x_max=1e3, resolution=1000):
+    r'''Sample magnitudes from a Schechter luminosity function.
 
-    r"""Model of Herbel et al (2017)
-
-    Luminosities following the Schechter luminosity function following the
-    Herbel et al. [1]_ model.
+    Given a list of galaxy redshifts, and an apparent magnitude limit, sample
+    galaxy absolute magnitudes from a Schechter luminosity function.
 
     Parameters
     ----------
-    redshift : (nz,) array-like
-        The redshift values at which to sample luminosities.
-    alpha : float or int
-        The alpha parameter in the Schechter luminosity function.
-    a_m, b_m : float or int
-        Factors parameterising the characteristic absolute magnitude M_* as
-        a linear function of redshift according to Equation 3.3 in [1]_.
-    size: int, optional
-         Output shape of luminosity samples. If size is None and redshift
-         is a scalar, a single sample is returned. If size is None and
-         redshift is an array, an array of samples is returned with the same
-         shape as redshift.
-    x_min, x_max : float or int, optional
-        Lower and upper luminosity bounds in units of L*.
-    resolution : int, optional
-        Resolution of the inverse transform sampling spline. Default is 100.
+    redshift : array_like
+        Galaxy redshifts for which to sample magnitudes.
+    M_star : array_like or function
+        Characteristic absolute magnitude, either constant, or an array with
+        values for each galaxy, or a function of galaxy redshift.
+    alpha : array_like or function
+        Schechter function index, either a constant, or an array of values for
+        each galaxy, or a function of galaxy redshift.
+    m_lim : float
+        Apparent magnitude limit.
+    cosmology : Cosmology, optional
+        Cosmology object for converting apparent and absolute magnitudes. If
+        no cosmology is given, the default cosmology is used.
+    size : int, optional
+        Explicit size for the sampling. If not given, one magnitude is sampled
+        for each redshift.
 
     Returns
     -------
-    luminosity : array_like
-        Drawn luminosities from the Schechter luminosity function. Luminosities
-        are B-band luminosities in units of solar luminosity.
-
-    Notes
-    -----
-    The Schechter luminosity function is given as
-
-    .. math::
-        \Phi(L, z) = \frac{\Phi_\star(z)}{L_\star(z)}
-            \left(\frac{L}{L_\star(z)}\right)^\alpha
-            \exp\left(-\frac{L}{L_\star(z)}\right) \;.
-
-    Here the luminosity is defined as
-
-    .. math::
-
-        L = 10^{-0.4M} \;,
-
-    with absolute magnitude :math:`M`. Furthermore, Herbel et al. [1]_
-    introduced
-
-    .. math::
-
-        \Phi_\star(z) = b_\phi \exp(a_\phi z) \;,
-        M_\star(z) = a_M z + b_M \;.
-
-    Now we have to rescale the Schechter function by the comoving element and
-    get
-
-    .. math::
-
-        \phi(L,z) = \frac{d_H d_M^2}{E(z)}  \Phi(L,z)\;.
-
-    References
-    ----------
-    .. [1] Herbel J., Kacprzak T., Amara A. et al., 2017, Journal of Cosmology
-        and Astroparticle Physics, Issue 08, article id. 035 (2017)
+    magnitude : array_like
+        Absolute magnitude sampled from a Schechter luminosity function for
+        each input galaxy redshift.
 
     Examples
     --------
-    >>> import skypy.galaxy.luminosity as lum
 
-    Sample 100 luminosity values at redshift z = 1.0 with
-    a_m = -0.9408582, b_m = -20.40492365, alpha = -1.3.
+    Sample a number of blue (alpha = -1.3, M_star = -20.5) galaxy magnitudes
+    brighter than m = 22.0 around redshift 0.5.
 
-    >>> luminosities = lum.herbel_luminosities(1.0, -1.3, -0.9408582,
-    ...                                         -20.40492365, size=100)
+    >>> import numpy as np
+    >>> from skypy.galaxy.luminosity import schechter_lf_magnitude
+    >>> z = np.random.uniform(4.9, 5.1, size=20)
+    >>> M = schechter_lf_magnitude(z, -20.5, -1.3, 22.0)
 
-    Sample a luminosity value for every redshift in an array z with
-    a_m = -0.9408582, b_m = -20.40492365, alpha = -1.3.
+    '''
 
-    >>> z = np.linspace(0,2, 100)
-    >>> luminosities = lum.herbel_luminosities(z, -1.3, -0.9408582,
-    ...                                         -20.40492365)
+    # only alpha scalars supported at the moment
+    if np.ndim(alpha) > 0:
+        raise NotImplementedError('only scalar alpha is supported')
 
-    """
+    # get x_min for each galaxy
+    x_min = m_lim - cosmology.distmod(redshift).value
+    x_min -= M_star
+    x_min *= -0.4
+    if np.ndim(x_min) > 0:
+        np.power(10., x_min, out=x_min)
+    else:
+        x_min = 10.**x_min
 
-    if size is None and np.shape(redshift):
-        size = np.shape(redshift)
+    # sample magnitudes
+    #   x == 10**(-0.4*(M - M_star))
+    M = schechter(alpha, x_min, x_max, resolution, size=size)
+    np.log10(M, out=M)
+    M *= -2.5
+    M += M_star
 
-    # this is the AB zeropoint of the B-band in units of solar luminosity
-    zeropoint = -4.73
-
-    luminosity_star = _calculate_luminosity_star(redshift, a_m, b_m, zeropoint)
-
-    x_sample = schechter(alpha, x_min, x_max, resolution=resolution, size=size)
-
-    return luminosity_star * x_sample
-
-
-def _calculate_luminosity_star(redshift, a_m, b_m, zeropoint=None):
-    absolute_magnitude_star = a_m * redshift + b_m
-    return astro.luminosity_from_absolute_magnitude(absolute_magnitude_star, zeropoint)
+    return M

--- a/skypy/galaxy/tests/test_luminosity.py
+++ b/skypy/galaxy/tests/test_luminosity.py
@@ -1,69 +1,51 @@
 import numpy as np
-import scipy.stats
-import scipy.integrate
-import scipy.special
-import pytest
-
-import skypy.galaxy.luminosity as lum
-import skypy.utils.special as special
-import skypy.utils.astronomy as astro
+from scipy.stats import kstest
 
 
-def test_calculate_luminosity_star():
-    luminosity_star = lum._calculate_luminosity_star(1, 2.5, 5)
-    assert luminosity_star == 0.001
+def test_schechter_lf_magnitude():
+    from skypy.galaxy.luminosity import schechter_lf_magnitude
+    from astropy.cosmology import default_cosmology
+    import pytest
 
-    redshift = np.array([0.1, 0.6, 1])
-    luminosity_star = lum._calculate_luminosity_star(redshift, 2.5, 5)
-    result = np.array([0.00794328, 0.00251189, 0.001])
-    np.testing.assert_allclose(luminosity_star, result, rtol=1e-05)
+    # use default cosmology
+    cosmo = default_cosmology.get()
 
+    # Schechter function parameters for tests
+    M_star = -20.5
+    alpha = -1.3
 
-def test_herbel_luminosities():
-    # Test that error is returned if redshift input is an array but size !=
-    # None and size != redshift,size
-    with pytest.raises(ValueError):
-        lum.herbel_luminosities(np.array([1, 2]), -1.3, -0.9408582,
-                                -20.40492365, size=3)
+    # sample 1000 galaxies at a fixed redshift of 1.0
+    z = np.repeat(1.0, 1000)
+    M = schechter_lf_magnitude(z, M_star, alpha, 30., cosmo)
 
-    # Test that sampling corresponds to sampling from the right pdf.
-    # For this, we sample an array of luminosities for redshift z = 1.0 and we
-    # compare it to the corresponding cdf.
-    # The B-band zeropoint for the model is -4.73.
+    # get the distribution function
+    log10_x_min = -0.4*(30. - cosmo.distmod(1.0).value - M_star)
+    x = np.logspace(log10_x_min, log10_x_min + 3, 1000)
+    pdf = x**(alpha+1)*np.exp(-x)
+    cdf = np.concatenate([[0.], np.cumsum((pdf[1:]+pdf[:-1])/2*np.diff(np.log(x)))])
+    cdf /= cdf[-1]
 
-    def calc_pdf(luminosity, z, alpha, a_m, b_m, absolute_magnitude_max=-16.0,
-                 absolute_magnitude_min=-28.0):
-        luminosity_min = astro.luminosity_from_absolute_magnitude(
-            absolute_magnitude_max, -4.73)
-        luminosity_max = astro.luminosity_from_absolute_magnitude(
-            absolute_magnitude_min, -4.73)
-        lum_star = lum._calculate_luminosity_star(z, a_m, b_m, -4.73)
-        c = np.fabs(special.gammaincc(alpha+1, luminosity_min/lum_star))
-        d = np.fabs(special.gammaincc(alpha+1, luminosity_max/lum_star))
-        return 1./lum_star*np.power(luminosity/lum_star, alpha)*np.exp(
-                -luminosity/lum_star-scipy.special.gammaln(alpha+1))/(c - d)
+    # test the samples against the CDF
+    D, p = kstest(10.**(-0.4*(M - M_star)), lambda t: np.interp(t, x, cdf))
+    assert p > 0.01, 'D = {}, p = {}'.format(D, p)
 
-    def calc_cdf(L):
-        a_m = -0.9408582
-        b_m = -20.40492365
-        alpha = -1.3
-        pdf = calc_pdf(L, 1.0, alpha, a_m, b_m)
-        cdf = scipy.integrate.cumtrapz(pdf, L, initial=0)
-        cdf = cdf / cdf[-1]
-        return cdf
+    # test for 1000 galaxies with Pareto redshift distribution
+    z = np.random.pareto(3., size=1000)
 
-    sample = lum.herbel_luminosities(1.0, -1.3, -0.9408582, -20.40492365,
-                                     size=1000)
-    p_value = scipy.stats.kstest(sample, calc_cdf)[1]
-    assert p_value >= 0.01
+    # for scalar parameters, sample galaxies with magnitude limit of 30
+    M = schechter_lf_magnitude(z, M_star, alpha, 30., cosmo)
 
+    # check that the output has the correct shape
+    assert np.shape(M) == (1000,)
 
-def test_exponential_distribution():
-    # When alpha=0, L*=1 and x_min~0 we get a truncated exponential
-    # the b_m value offsets the B-band zeropoint of -4.73
-    q_max = 1e2
-    sample = lum.herbel_luminosities(0, 0, 0, 4.73, size=1000,
-                                     x_min=1e-10, x_max=q_max,
-                                     resolution=1000)
-    d, p_value = scipy.stats.kstest(sample, 'truncexpon', args=(q_max,))
-    assert p_value >= 0.01
+    # make sure magnitude limit was respected
+    M_lim = 30. - cosmo.distmod(z).value
+    assert np.all(M <= M_lim)
+
+    # sample with array for alpha
+    # not implemented at the moment
+    with pytest.raises(NotImplementedError):
+        M = schechter_lf_magnitude(z, M_star, np.broadcast_to(alpha, z.shape), 30., cosmo)
+
+    # sample with an explicit size
+    schechter_lf_magnitude(1.0, M_star, alpha, 30., cosmo, size=100)

--- a/skypy/galaxy/tests/test_redshift.py
+++ b/skypy/galaxy/tests/test_redshift.py
@@ -1,12 +1,89 @@
 import numpy as np
 
-from skypy.galaxy.redshift import smail, herbel_redshift, herbel_pdf
-from unittest.mock import patch
-from scipy.stats import kstest, norm
-import scipy.integrate
+from scipy.stats import kstest
+
+
+def test_schechter_lf_redshift():
+
+    from skypy.galaxy.redshift import schechter_lf_redshift, redshifts_from_comoving_density
+    from astropy.cosmology import FlatLambdaCDM
+    from scipy.special import gamma, gammaincc
+
+    # fix this cosmology
+    cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
+
+    # parameters for the sampling
+    z = np.linspace(1e-10, 2., 1000)
+    M_star = -20
+    phi_star = 1e-3
+    alpha = -0.5
+    m_lim = 30.
+    fsky = 1/41253
+
+    # sample redshifts
+    z_gal = schechter_lf_redshift(z, M_star, phi_star, alpha, m_lim, fsky, cosmo, noise=False)
+
+    # the absolute magnitude limit as function of redshift
+    M_lim = m_lim - cosmo.distmod(z).value
+
+    # lower limit of unscaled Schechter random variable
+    x_min = 10.**(-0.4*(M_lim - M_star))
+
+    # density with factor from upper incomplete gamma function
+    density = phi_star*gamma(alpha+1)*gammaincc(alpha+1, x_min)
+
+    # turn into galaxies/surface area
+    density *= 4*np.pi*fsky*cosmo.differential_comoving_volume(z).to_value('Mpc3/sr')
+
+    # integrate total number
+    n_gal = np.trapz(density, z, axis=-1)
+
+    # make sure noise-free sample has right size
+    assert np.isclose(len(z_gal), n_gal, atol=1.0)
+
+    # turn density into CDF
+    cdf = density  # same memory
+    np.cumsum((density[1:]+density[:-1])/2*np.diff(z), out=cdf[1:])
+    cdf[0] = 0
+    cdf /= cdf[-1]
+
+    # check distribution of sample
+    D, p = kstest(z_gal, lambda z_: np.interp(z_, z, cdf))
+    assert p > 0.01, 'D = {}, p = {}'.format(D, p)
+
+
+def test_redshifts_from_comoving_density():
+
+    from skypy.galaxy.redshift import redshifts_from_comoving_density
+    from astropy.cosmology import LambdaCDM
+
+    # random cosmology
+    H0 = np.random.uniform(50, 100)
+    Om = np.random.uniform(0.1, 0.9)
+    Ol = np.random.uniform(0.1, 0.9)
+    cosmo = LambdaCDM(H0=H0, Om0=Om, Ode0=Ol)
+
+    # fixed comoving density of Ngal galaxies total
+    Ngal = 1000
+    redshift = np.arange(0.0, 2.001, 0.1)
+    density = Ngal/cosmo.comoving_volume(redshift[-1]).to_value('Mpc3')
+    fsky = 1.0
+
+    # sample galaxies over full sky without Poisson noise
+    z_gal = redshifts_from_comoving_density(redshift, density, fsky, cosmo, noise=False)
+
+    # make sure number of galaxies is correct (no noise)
+    assert np.isclose(len(z_gal), Ngal, atol=1, rtol=0)
+
+    # test the distribution of the sample against the analytical CDF
+    V_max = cosmo.comoving_volume(redshift[-1]).to_value('Mpc3')
+    D, p = kstest(z_gal, lambda z: cosmo.comoving_volume(z).to_value('Mpc3')/V_max)
+    assert p > 0.01, 'D = {}, p = {}'.format(D, p)
 
 
 def test_smail():
+    from skypy.galaxy.redshift import smail
+
     # sample a single redshift
     rvs = smail(1.3, 2.0, 1.5)
     assert np.isscalar(rvs)
@@ -31,59 +108,3 @@ def test_smail():
     # check sampling, the distribution is a generalised gamma distribution
     D, p = kstest(smail(0.832555, 1, 2, size=1000), 'gengamma', args=(1, 2))
     assert p > 0.01, 'D = {}, p = {}'.format(D, p)
-
-
-def test_herbel_pdf():
-    from astropy.cosmology import FlatLambdaCDM
-    cosmology = FlatLambdaCDM(H0=70, Om0=0.3, Tcmb0=2.725)
-    pdf = herbel_pdf(np.array([0.01, 0.5, 1, 2]),
-                     -0.5, -0.70596888,
-                     0.0035097, -0.70798041,
-                     -20.37196157, cosmology, -16.0)
-    result = np.array(
-        [4.09063927e+04, 4.45083420e+07, 7.26629445e+07, 5.40766813e+07])
-    np.testing.assert_allclose(pdf, result)
-
-
-# Test whether principle of the interpolation works. Let PDF return the PDF
-# of a Gaussian and sample from the corresponding CDF. Then compare the
-# first three moment of the returned sample with the Gaussian one.
-@patch('skypy.galaxy.redshift.herbel_pdf')
-def test_herbel_redshift_gauss(herbel_pdf):
-    from astropy.cosmology import FlatLambdaCDM
-    cosmology = FlatLambdaCDM(H0=70, Om0=0.3, Tcmb0=2.725)
-    resolution = 100
-    x = np.linspace(-5, 5, resolution)
-    herbel_pdf.side_effect = [norm.pdf(x)]
-    sample = herbel_redshift(alpha=-1.3, a_phi=-0.10268436,
-                             a_m=-0.9408582, b_phi=0.00370253,
-                             b_m=-20.40492365, cosmology=cosmology,
-                             low=-5., high=5.0, size=1000000,
-                             resolution=resolution)
-    p_value = kstest(sample, 'norm')[1]
-    assert p_value >= 0.01
-
-
-# Test that the sampling follows the pdf of Schechter function.
-def test_herbel_redshift_sampling():
-    from astropy.cosmology import FlatLambdaCDM
-    cosmology = FlatLambdaCDM(H0=70, Om0=0.3, Tcmb0=2.725)
-    sample = herbel_redshift(alpha=-1.3, a_phi=-0.10268436,
-                             a_m=-0.9408582, b_phi=0.00370253,
-                             b_m=-20.40492365, cosmology=cosmology,
-                             size=1000)
-
-    def calc_cdf(z):
-        pdf = herbel_pdf(z, alpha=-1.3,
-                         a_phi=-0.10268436,
-                         a_m=-0.9408582,
-                         b_phi=0.00370253,
-                         b_m=-20.40492365,
-                         cosmology=cosmology,
-                         absolute_magnitude_max=-16)
-        cdf = scipy.integrate.cumtrapz(pdf, z, initial=0)
-        cdf = cdf / cdf[-1]
-        return cdf
-
-    p_value = kstest(sample, calc_cdf)[1]
-    assert p_value >= 0.01

--- a/skypy/galaxy/tests/test_schechter.py
+++ b/skypy/galaxy/tests/test_schechter.py
@@ -1,0 +1,33 @@
+import numpy as np
+from scipy.stats import kstest
+
+
+def test_schechter_lf():
+
+    from pytest import raises
+    from skypy.galaxy import schechter_lf
+
+    # redshift and magnitude distributions are tested separately
+    # only test that output is consistent here
+
+    # parameters for the sampling
+    z = np.linspace(0., 1., 100)
+    M_star = -20
+    phi_star = 1e-3
+    alpha = -0.5
+    m_lim = 30.
+    fsky = 1/41253
+
+    # sample redshifts and magnitudes
+    z_gal, M_gal = schechter_lf(z, M_star, phi_star, alpha, m_lim, fsky)
+
+    # check length
+    assert len(z_gal) == len(M_gal)
+
+    # turn M_star, phi_star, alpha into arrays
+    z, M_star, phi_star, alpha = np.broadcast_arrays(z, M_star, phi_star, alpha)
+
+    # sample s.t. arrays need to be interpolated
+    # alpha array not yet supported
+    with raises(NotImplementedError):
+        z_gal, M_gal = schechter_lf(z, M_star, phi_star, alpha, m_lim, fsky)


### PR DESCRIPTION
## Description

This is an attempt to refactor the Schechter luminosity function sampling to use arbitrary models for `phi_star` and `M_star`.

This PR is based on #271 (but does not require it), so it should be merged after.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request