### PR TITLE
improved Schechter random sampling

### DIFF
--- a/skypy/utils/random.py
+++ b/skypy/utils/random.py
@@ -61,8 +61,9 @@ def schechter(alpha, x_min, x_max, resolution=100, size=None, scale=1.):
 
     lnx = np.linspace(np.min(lnx_min), np.max(lnx_max), resolution)
 
-    cdf = np.exp(np.add(alpha, 1)*lnx - np.exp(lnx))
-    np.cumsum((cdf[1:]+cdf[:-1])/2*np.diff(lnx), out=cdf[1:])
+    pdf = np.exp(np.add(alpha, 1)*lnx - np.exp(lnx))
+    cdf = pdf  # in place
+    np.cumsum((pdf[1:]+pdf[:-1])/2*np.diff(lnx), out=cdf[1:])
     cdf[0] = 0
     cdf /= cdf[-1]
 

--- a/skypy/utils/random.py
+++ b/skypy/utils/random.py
@@ -15,7 +15,6 @@ Utility Functions
 """
 
 import numpy as np
-import skypy.utils.special as special
 
 
 def schechter(alpha, x_min, x_max, resolution=100, size=None):
@@ -50,21 +49,19 @@ def schechter(alpha, x_min, x_max, resolution=100, size=None):
     .. [1] https://en.wikipedia.org/wiki/Luminosity_function_(astronomy)
     """
 
-    x = np.logspace(np.log10(np.min(x_min)), np.log10(np.max(x_max)),
-                    resolution)
-    cdf = _schechter_cdf(x, np.min(x_min), np.max(x_max), alpha)
-    t_lower = np.interp(x_min, x, cdf)
-    t_upper = np.interp(x_max, x, cdf)
+    lnx_min = np.log(x_min)
+    lnx_max = np.log(x_max)
+
+    lnx = np.linspace(np.min(lnx_min), np.max(lnx_max), resolution)
+
+    cdf = np.exp(np.add(alpha, 1)*lnx - np.exp(lnx))
+    np.cumsum((cdf[1:]+cdf[:-1])/2*np.diff(lnx), out=cdf[1:])
+    cdf[0] = 0
+    cdf /= cdf[-1]
+
+    t_lower = np.interp(lnx_min, lnx, cdf)
+    t_upper = np.interp(lnx_max, lnx, cdf)
     u = np.random.uniform(t_lower, t_upper, size=size)
-    x_sample = np.interp(u, cdf, x)
+    lnx_sample = np.interp(u, cdf, lnx)
 
-    return x_sample
-
-
-def _schechter_cdf(x, x_min, x_max, alpha):
-    a = special.gammaincc(alpha + 1, x_min)
-    b = special.gammaincc(alpha + 1, x)
-    c = special.gammaincc(alpha + 1, x_min)
-    d = special.gammaincc(alpha + 1, x_max)
-
-    return (a - b) / (c - d)
+    return np.exp(lnx_sample)

--- a/skypy/utils/tests/test_random.py
+++ b/skypy/utils/tests/test_random.py
@@ -34,12 +34,12 @@ def test_schechter():
 
     # Test output shape when scale is a scalar
     scale = 5
-    samples = random.schechter(alpha, x_min, x_max, scale=scale)
+    samples = schechter(alpha, x_min, x_max, scale=scale)
     assert np.shape(samples) == np.shape(scale)
 
     # Test output shape when scale is an array
     scale = np.random.uniform(size=10)
-    samples = random.schechter(alpha, x_min, x_max, scale=scale)
+    samples = schechter(alpha, x_min, x_max, scale=scale)
     assert np.shape(samples) == np.shape(scale)
 
 

--- a/skypy/utils/tests/test_random.py
+++ b/skypy/utils/tests/test_random.py
@@ -6,11 +6,12 @@ from scipy.stats import kstest
 def test_schechter():
 
     from skypy.utils.random import schechter
+    from skypy.utils.special import gammaincc
 
     def schechter_cdf_gen(alpha, x_min, x_max):
-        a = special.gammaincc(alpha + 1, x_min)
-        b = special.gammaincc(alpha + 1, x_max)
-        return lambda x: (a - special.gammaincc(alpha + 1, x)) / (a - b)
+        a = gammaincc(alpha + 1, x_min)
+        b = gammaincc(alpha + 1, x_max)
+        return lambda x: (a - gammaincc(alpha + 1, x)) / (a - b)
 
     # Test the schechter function, sampling dimensionless x values
     alpha = -1.3
@@ -44,10 +45,10 @@ def test_schechter_gamma():
 
     # when alpha > -1, x_min ≈ 0, x_max ≈ ∞, distribution is gamma
     alpha = np.random.uniform(-1, 2)
-    x_min = 1e-10
-    x_max = 1e+10
+    x_min = 1e-20
+    x_max = 1e+20
+    scale = 2.5
 
-    scale = 5
     x = schechter(alpha, x_min, x_max, resolution=100000, size=1000, scale=scale)
 
     _, p = kstest(x, 'gamma', args=(alpha+1, 0, scale))

--- a/skypy/utils/tests/test_random.py
+++ b/skypy/utils/tests/test_random.py
@@ -22,7 +22,7 @@ def test_schechter():
     x_min = 1e-10
     x_max = 1e2
 
-    x = schechter(alpha, x_min=x_min, x_max=x_max, resolution=100, size=1000)
+    x = schechter(alpha, x_min=x_min, x_max=x_max, size=1000)
 
     assert np.all(x >= x_min)
     assert np.all(x <= x_max)
@@ -30,4 +30,19 @@ def test_schechter():
     # Test the distribution of galaxy properties follows the right distribution
     cdf = schechter_cdf_gen(alpha, x_min, x_max)
     _, p = kstest(x, cdf)
+    assert p > 0.01
+
+
+def test_schechter_gamma():
+
+    from skypy.utils.random import schechter
+
+    # when alpha > -1, x_min ≈ 0, x_max ≈ ∞, distribution is gamma
+    alpha = np.random.uniform(-1, 2)
+    x_min = 1e-10
+    x_max = 1e+10
+
+    x = schechter(alpha, x_min, x_max, resolution=100000, size=1000)
+
+    _, p = kstest(x, 'gamma', args=(alpha+1,))
     assert p > 0.01


### PR DESCRIPTION
## Description

Improves the efficiency of `skypy.utils.random.schechter()` by not computing the special function, and instead cumulatively summing the (simple) PDF. Since the inverse transform sampling with a fixed grid relies on the function being approximately linear on the grid scale, there is no advantage in computing the CDF instead of summing the PDF on the grid scale.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request