### PR TITLE
mirror examples to repository

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -1,0 +1,66 @@
+name: Mirror Examples
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * *'
+jobs:
+  examples:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+      with:
+        repository: skypyproject/examples
+        fetch-depth: 0
+    - name: Configure git
+      run: |
+        git config user.name github-actions
+        git config user.email github-actions@github.com
+        git config advice.detachedHead false
+    - name: Clone SkyPy
+      run: |
+        git clone https://github.com/skypyproject/skypy.git
+
+        cd skypy
+        branches=$(git branch --format='%(refname:short)')
+        tags=$(git tag)
+        cd ..
+
+        echo "branches: $(echo ${branches})"
+        echo "::set-env name=branches::$(echo ${branches})"
+
+        echo "tags: $(echo ${tags})"
+        echo "::set-env name=tags::$(echo ${tags})"
+    - name: Mirror Branches
+      run: |
+        for b in ${branches}; do
+          (git checkout -qf ${b} 2> /dev/null && echo "checkout ${b}") || (git checkout -qf --orphan ${b} && git rm -qrf . && echo "branch ${b}")
+          cd skypy && git checkout -qf ${b} && cd ..
+          for file in LICENSE.rst examples; do
+            rm -rf ${file}
+            if [ -e skypy/${file} ]; then
+              cp -a skypy/${file} .
+              git add ${file}
+            fi
+          done
+          git checkout master -- README.md
+          git diff --cached --quiet || git commit -qm "branch ${b}"
+        done
+        git push -f --all origin
+    - name: Mirror Tags
+      run: |
+        for t in ${tags}; do
+          (git checkout -qf ${t} 2> /dev/null && echo "checkout ${t}") || (git checkout -qf --orphan ${t} && git rm -qrf . && echo "tag ${t}")
+          cd skypy && git checkout -qf ${t} && cd ..
+          for file in LICENSE.rst examples; do
+            rm -rf ${file}
+            if [ -e skypy/${file} ]; then
+              cp -a skypy/${file} .
+              git add ${file}
+            fi
+          done
+          git checkout master -- README.md
+          git diff --cached --quiet || git commit -qm "tag ${t}"
+          git tag -f ${t}
+        done
+        git push -f --tags origin

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -1,7 +1,5 @@
 name: Mirror Examples
 on:
-  push:
-  release:
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * *'
@@ -22,12 +20,14 @@ jobs:
         git config advice.detachedHead false
     - name: Clone SkyPy
       run: |
-        git clone https://github.com/skypyproject/skypy.git
+        pushd ..
 
+        git clone https://github.com/skypyproject/skypy.git
         cd skypy
         branches=$(git branch --format='%(refname:short)')
         tags=$(git tag)
-        cd ..
+
+        popd
 
         echo "branches: $(echo ${branches})"
         echo "::set-env name=branches::$(echo ${branches})"
@@ -37,15 +37,12 @@ jobs:
     - name: Mirror Branches
       run: |
         for b in ${branches}; do
-          (git checkout -qf ${b} 2> /dev/null && echo "checkout ${b}") || (git checkout -qf --orphan ${b} && git rm -qrf . && echo "branch ${b}")
-          cd skypy && git checkout -qf ${b} && cd ..
-          for file in LICENSE.rst examples; do
-            rm -rf ${file}
-            if [ -e skypy/${file} ]; then
-              cp -a skypy/${file} .
-              git add ${file}
-            fi
-          done
+          (git checkout -qf ${b} 2> /dev/null && echo "checkout ${b}") || (git checkout -qf --orphan ${b} && echo "branch ${b}")
+          git rm -qrf .
+          cd ../skypy && git checkout -qf ${b} && cd -
+          cp -a $(find ../skypy -maxdepth 2 -name LICENSE.rst) .
+          cp -a ../skypy/examples/* .
+          git add -Af
           git checkout master -- README.md
           git diff --cached --quiet || git commit -qm "branch ${b}"
         done
@@ -53,15 +50,12 @@ jobs:
     - name: Mirror Tags
       run: |
         for t in ${tags}; do
-          (git checkout -qf ${t} 2> /dev/null && echo "checkout ${t}") || (git checkout -qf --orphan ${t} && git rm -qrf . && echo "tag ${t}")
-          cd skypy && git checkout -qf ${t} && cd ..
-          for file in LICENSE.rst examples; do
-            rm -rf ${file}
-            if [ -e skypy/${file} ]; then
-              cp -a skypy/${file} .
-              git add ${file}
-            fi
-          done
+          (git checkout -qf ${t} 2> /dev/null && echo "checkout ${t}") || (git checkout -qf --orphan ${t} && echo "tag ${t}")
+          git rm -qrf .
+          cd ../skypy && git checkout -qf ${t} && cd -
+          cp -a $(find ../skypy -maxdepth 2 -name LICENSE.rst) .
+          cp -a ../skypy/examples/* .
+          git add -Af
           git checkout master -- README.md
           git diff --cached --quiet || git commit -qm "tag ${t}"
           git tag -f ${t}

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -1,8 +1,15 @@
 name: Mirror Examples
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 4 * * *'
+  push:
+    branches:
+      - master
+      - 'v[0-9]+.*'
+    tags:
+      - 'v[0-9]+.*'
+    paths:
+      - 'examples/**'
+      - LICENSE.rst
 jobs:
   examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -1,5 +1,7 @@
 name: Mirror Examples
 on:
+  push:
+  release:
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * *'

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -13,6 +13,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: skypyproject/examples
+        token: ${{ secrets.EXAMPLES_TOKEN }}
         fetch-depth: 0
     - name: Configure git
       run: |

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -1,6 +1,5 @@
 name: Mirror Examples
 on:
-  push:
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * *'

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -25,20 +25,22 @@ jobs:
         git config --global user.name skypybot
         git config --global user.email skypybot@users.noreply.github.com
         git config --global advice.detachedHead false
-    - name: Mirror Branches
+    - name: Mirror Branches and Tags
       run: |
         cd skypy
         branches=$(git branch -r --format='%(refname:short)' | cut -d/ -f2 | grep -E '^master$|^v')
+        tags=$(git tag | grep -E '^v')
+        refs="${branches} ${tags}"
         cd ..
 
-        for b in ${branches}; do
+        for ref in ${refs}; do
           cd examples
-          (git checkout -qf ${b} 2> /dev/null && echo "checkout ${b}") || (git checkout -qf --orphan ${b} && echo "branch ${b}")
+          (git checkout -qf ${ref} 2> /dev/null && echo "update ${ref}") || (git checkout -qf --orphan ${ref} && echo "create ${ref}")
           git rm -qrf .
           cd ..
 
           cd skypy
-          git checkout -qf ${b}
+          git checkout -qf ${ref}
           cd ..
 
           cp -a $(find skypy -maxdepth 2 -name LICENSE.rst) examples/
@@ -47,40 +49,16 @@ jobs:
           cd examples
           git add -Af
           git checkout master -- README.md
-          git diff --cached --quiet || git commit -qm "branch ${b}"
+          git diff --cached --quiet || git commit -qm "${ref}"
+          if [ -n "$(echo "${tags}" | grep "${ref}")" ]; then
+            git tag -f ${ref}
+            git symbolic-ref -q HEAD > /dev/null && git checkout -qf --detach && git branch -qD ${ref}
+          fi
           cd ..
         done
-
+    - name: Push Changes
+      run: |
         cd examples
         git push -f --all origin
-        cd ..
-    - name: Mirror Tags
-      run: |
-        cd skypy
-        tags=$(git tag | grep -E '^v')
-        cd ..
-
-        for t in ${tags}; do
-          cd examples
-          (git checkout -qf ${t} 2> /dev/null && echo "checkout ${t}") || (git checkout -qf --orphan ${t} && echo "tag ${t}")
-          git rm -qrf .
-          cd ..
-
-          cd skypy
-          git checkout -qf ${t}
-          cd ..
-
-          cp -a $(find skypy -maxdepth 2 -name LICENSE.rst) examples/
-          cp -a skypy/examples/* examples/
-
-          cd examples
-          git add -Af
-          git checkout master -- README.md
-          git diff --cached --quiet || git commit -qm "tag ${t}"
-          git tag -f ${t}
-          cd ..
-        done
-
-        cd examples
         git push -f --tags origin
         cd ..

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -1,5 +1,6 @@
 name: Mirror Examples
 on:
+  push:
   workflow_dispatch:
   schedule:
     - cron: '0 4 * * *'
@@ -7,57 +8,80 @@ jobs:
   examples:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout Repository
+    - name: Checkout SkyPy
+      uses: actions/checkout@v2
+      with:
+        repository: skypyproject/skypy
+        path: skypy
+        fetch-depth: 0
+    - name: Checkout Examples
       uses: actions/checkout@v2
       with:
         repository: skypyproject/examples
-        token: ${{ secrets.EXAMPLES_TOKEN }}
+        token: ${{ secrets.SKYPYBOT_TOKEN }}
+        path: examples
         fetch-depth: 0
     - name: Configure git
       run: |
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        git config advice.detachedHead false
-    - name: Clone SkyPy
-      run: |
-        pushd ..
-
-        git clone https://github.com/skypyproject/skypy.git
-        cd skypy
-        branches=$(git branch --format='%(refname:short)')
-        tags=$(git tag)
-
-        popd
-
-        echo "branches: $(echo ${branches})"
-        echo "::set-env name=branches::$(echo ${branches})"
-
-        echo "tags: $(echo ${tags})"
-        echo "::set-env name=tags::$(echo ${tags})"
+        git config --global user.name skypybot
+        git config --global user.email skypybot@users.noreply.github.com
+        git config --global advice.detachedHead false
     - name: Mirror Branches
       run: |
+        cd skypy
+        branches=$(git branch -r --format='%(refname:short)' | cut -d/ -f2 | grep -E '^master$|^v')
+        cd ..
+
         for b in ${branches}; do
+          cd examples
           (git checkout -qf ${b} 2> /dev/null && echo "checkout ${b}") || (git checkout -qf --orphan ${b} && echo "branch ${b}")
           git rm -qrf .
-          cd ../skypy && git checkout -qf ${b} && cd -
-          cp -a $(find ../skypy -maxdepth 2 -name LICENSE.rst) .
-          cp -a ../skypy/examples/* .
+          cd ..
+
+          cd skypy
+          git checkout -qf ${b}
+          cd ..
+
+          cp -a $(find skypy -maxdepth 2 -name LICENSE.rst) examples/
+          cp -a skypy/examples/* examples/
+
+          cd examples
           git add -Af
           git checkout master -- README.md
           git diff --cached --quiet || git commit -qm "branch ${b}"
+          cd ..
         done
+
+        cd examples
         git push -f --all origin
+        cd ..
     - name: Mirror Tags
       run: |
+        cd skypy
+        tags=$(git tag | grep -E '^v')
+        cd ..
+
         for t in ${tags}; do
+          cd examples
           (git checkout -qf ${t} 2> /dev/null && echo "checkout ${t}") || (git checkout -qf --orphan ${t} && echo "tag ${t}")
           git rm -qrf .
-          cd ../skypy && git checkout -qf ${t} && cd -
-          cp -a $(find ../skypy -maxdepth 2 -name LICENSE.rst) .
-          cp -a ../skypy/examples/* .
+          cd ..
+
+          cd skypy
+          git checkout -qf ${t}
+          cd ..
+
+          cp -a $(find skypy -maxdepth 2 -name LICENSE.rst) examples/
+          cp -a skypy/examples/* examples/
+
+          cd examples
           git add -Af
           git checkout master -- README.md
           git diff --cached --quiet || git commit -qm "tag ${t}"
           git tag -f ${t}
+          cd ..
         done
+
+        cd examples
         git push -f --tags origin
+        cd ..


### PR DESCRIPTION
This GitHub workflow should update the skypyproject/examples repository every night, mirroring all branches and tags of our library repository.