### PR TITLE
flag to show skypy version

### DIFF
--- a/skypy/pipeline/scripts/skypy.py
+++ b/skypy/pipeline/scripts/skypy.py
@@ -35,6 +35,7 @@ values as keyword arguments.
 """
 
 import argparse
+from skypy import __version__ as skypy_version
 from skypy.pipeline.driver import SkyPyDriver
 import sys
 
@@ -66,6 +67,7 @@ def main(args=None):
     import yaml
 
     parser = argparse.ArgumentParser(description="SkyPy pipeline driver")
+    parser.add_argument('--version', action='version', version=skypy_version)
     parser.add_argument('config', type=argparse.FileType('r'),
                         help='Config file name')
     parser.add_argument('-f', '--format', required=False,

--- a/skypy/pipeline/tests/test_skypy.py
+++ b/skypy/pipeline/tests/test_skypy.py
@@ -1,5 +1,8 @@
 from astropy.utils.data import get_pkg_data_filename
+from contextlib import redirect_stdout
+from io import StringIO
 import pytest
+from skypy import __version__ as skypy_version
 from skypy.pipeline.scripts import skypy
 
 
@@ -13,6 +16,14 @@ def test_skypy():
     # Argparse help
     with pytest.raises(SystemExit) as e:
         skypy.main(['--help'])
+    assert e.value.code == 0
+
+    # Argparse version
+    version = StringIO()
+    with pytest.raises(SystemExit) as e:
+        with redirect_stdout(version):
+            skypy.main(['--version'])
+    assert version.getvalue().strip() == skypy_version
     assert e.value.code == 0
 
     # Missing positional argument 'config'


### PR DESCRIPTION
Adds a flag to the `skypy` command that outputs the version of the library.

```bash
$ skypy --version
0.1.dev141+g84a818c
```