### PR TITLE
decouple merger_rate from herbel_luminosities

### DIFF
--- a/skypy/gravitational_wave/merger_rate.py
+++ b/skypy/gravitational_wave/merger_rate.py
@@ -69,14 +69,12 @@ def b_band_merger_rate(luminosity,
 
     Examples
     --------
-    >>> from skypy.galaxy.luminosity import herbel_luminosities
+    >>> import numpy as np
     >>> from skypy.gravitational_wave import b_band_merger_rate
 
-    Sample 100 luminosity values at redshift z = 1.0 with
-    a_m = -0.9408582, b_m = -20.40492365, alpha = -1.3.
+    Sample 100 luminosity values near absolute magnitude -20.5.
 
-    >>> luminosities = herbel_luminosities(1.0, -1.3, -0.9408582,
-    ...                                    -20.40492365, size=100)
+    >>> luminosities = 10.**(-0.4*(-20.5 + np.random.randn(100)))
 
     Generate merger rates for these luminosities.
 

--- a/skypy/gravitational_wave/tests/test_merger_rate.py
+++ b/skypy/gravitational_wave/tests/test_merger_rate.py
@@ -1,6 +1,5 @@
 import numpy as np
 from astropy import constants, units
-from skypy.galaxy.luminosity import herbel_luminosities
 from skypy.gravitational_wave import b_band_merger_rate
 from skypy.gravitational_wave.merger_rate import abadie_table_III
 
@@ -8,8 +7,7 @@ from skypy.gravitational_wave.merger_rate import abadie_table_III
 def test_abadie_rates():
 
     # Check the number of merger rates returned
-    z, alpha, a_m, b_m = 1.0, -1.3, -0.9408582, -20.40492365
-    luminosity = herbel_luminosities(z, alpha, a_m, b_m, size=1000)
+    luminosity = 10.**(-0.4*(-20.5 + np.random.randn(1000)))
     rates = b_band_merger_rate(luminosity, population='NS-NS', optimism='low')
     assert len(rates) == len(luminosity)
 


### PR DESCRIPTION
## Description

Do not use `herbel_luminosities` internally in the `merger_rate` module.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
