### PR TITLE
use specutils for spectrum and bandpass definitions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ python_requires = >=3.6
 setup_requires = setuptools_scm
 install_requires =
     astropy
+    specutils
     networkx
     numpy
     scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ python_requires = >=3.6
 setup_requires = setuptools_scm
 install_requires =
     astropy
-    specutils
     networkx
     numpy
     scipy
@@ -31,8 +30,10 @@ console_scripts =
 [options.extras_require]
 test =
     pytest-astropy
+    specutils
 all =
     camb
+    specutils
 docs =
     sphinx-astropy
     matplotlib

--- a/skypy/galaxy/spectrum.py
+++ b/skypy/galaxy/spectrum.py
@@ -3,7 +3,7 @@ r"""Galaxy spectrum module.
 """
 
 import numpy as np
-import astropy.units as u
+from astropy import units
 from astropy.io.fits import getdata
 
 
@@ -231,11 +231,11 @@ def mag_ab(spectrum, bandpass, redshift=None):
     '''
 
     # get the spectrum and bandpass
-    spec_lam = spectrum.wavelength.to_value(u.AA, equivalencies=u.spectral())
+    spec_lam = spectrum.wavelength.to_value(units.AA, equivalencies=units.spectral())
     spec_flux = spectrum.flux.to_value('erg s-1 cm-2 AA-1',
-                                       equivalencies=u.spectral_density(spec_lam))
-    band_lam = bandpass.wavelength.to_value(u.AA, equivalencies=u.spectral())
-    band_tx = bandpass.flux.to_value(u.dimensionless_unscaled)
+                                       equivalencies=units.spectral_density(spec_lam))
+    band_lam = bandpass.wavelength.to_value(units.AA, equivalencies=units.spectral())
+    band_tx = bandpass.flux.to_value(units.dimensionless_unscaled)
 
     # redshift zero if not given
     if redshift is None:

--- a/skypy/galaxy/spectrum.py
+++ b/skypy/galaxy/spectrum.py
@@ -231,11 +231,11 @@ def mag_ab(spectrum, bandpass, redshift=None):
     '''
 
     # get the spectrum and bandpass
-    spec_lam = spectrum.wavelength.to_value('AA', equivalencies=u.spectral())
+    spec_lam = spectrum.wavelength.to_value(u.AA, equivalencies=u.spectral())
     spec_flux = spectrum.flux.to_value('erg s-1 cm-2 AA-1',
                                        equivalencies=u.spectral_density(spec_lam))
-    band_lam = bandpass.wavelength.to_value('AA', equivalencies=u.spectral())
-    band_tx = bandpass.flux.to_value('adu')
+    band_lam = bandpass.wavelength.to_value(u.AA, equivalencies=u.spectral())
+    band_tx = bandpass.flux.to_value(u.dimensionless_unscaled)
 
     # redshift zero if not given
     if redshift is None:

--- a/skypy/galaxy/tests/test_spectrum.py
+++ b/skypy/galaxy/tests/test_spectrum.py
@@ -7,9 +7,9 @@ from astropy.io.fits import getdata
 try:
     import specutils
 except ImportError:
-    SPECUTILS_FOUND = False
+    HAS_SPECUTILS = False
 else:
-    SPECUTILS_FOUND = True
+    HAS_SPECUTILS = True
 
 
 from skypy.galaxy.spectrum import dirichlet_coefficients, kcorrect_spectra
@@ -93,21 +93,21 @@ def test_kcorrect_spectra():
     assert np.allclose(sed, templates[0])
 
 
-@pytest.mark.skipif(not SPECUTILS_FOUND, reason='test requires specutils')
+@pytest.mark.skipif(not HAS_SPECUTILS, reason='test requires specutils')
 def test_mag_ab_standard_source():
 
-    import astropy.units as u
+    from astropy import units
 
     from skypy.galaxy.spectrum import mag_ab
 
     # create a bandpass
-    bp_lam = np.logspace(0, 4, 1000)*u.AA
-    bp_tx = np.exp(-((bp_lam - 1000*u.AA)/(100*u.AA))**2)*u.dimensionless_unscaled
+    bp_lam = np.logspace(0, 4, 1000)*units.AA
+    bp_tx = np.exp(-((bp_lam - 1000*units.AA)/(100*units.AA))**2)*units.dimensionless_unscaled
     bp = specutils.Spectrum1D(spectral_axis=bp_lam, flux=bp_tx)
 
     # test that the AB standard source has zero magnitude
-    lam = np.logspace(0, 4, 1000)*u.AA
-    flam = 0.10884806248538730623*u.Unit('erg s-1 cm-2 AA')/lam**2
+    lam = np.logspace(0, 4, 1000)*units.AA
+    flam = 0.10884806248538730623*units.Unit('erg s-1 cm-2 AA')/lam**2
     spec = specutils.Spectrum1D(spectral_axis=lam, flux=flam)
 
     m = mag_ab(spec, bp)
@@ -115,21 +115,21 @@ def test_mag_ab_standard_source():
     assert np.isclose(m, 0)
 
 
-@pytest.mark.skipif(not SPECUTILS_FOUND, reason='test requires specutils')
+@pytest.mark.skipif(not HAS_SPECUTILS, reason='test requires specutils')
 def test_mag_ab_redshift_dependence():
 
-    import astropy.units as u
+    from astropy import units
 
     from skypy.galaxy.spectrum import mag_ab
 
     # make a wide tophat bandpass
-    bp_lam = np.logspace(-10, 10, 3)*u.AA
-    bp_tx = np.ones(3)*u.dimensionless_unscaled
+    bp_lam = np.logspace(-10, 10, 3)*units.AA
+    bp_tx = np.ones(3)*units.dimensionless_unscaled
     bp = specutils.Spectrum1D(spectral_axis=bp_lam, flux=bp_tx)
 
     # create a narrow gaussian source
-    lam = np.logspace(0, 3, 1000)*u.AA
-    flam = np.exp(-((lam - 100*u.AA)/(10*u.AA))**2)*u.Unit('erg s-1 cm-2 AA-1')
+    lam = np.logspace(0, 3, 1000)*units.AA
+    flam = np.exp(-((lam - 100*units.AA)/(10*units.AA))**2)*units.Unit('erg s-1 cm-2 AA-1')
     spec = specutils.Spectrum1D(spectral_axis=lam, flux=flam)
 
     # array of redshifts

--- a/skypy/galaxy/tests/test_spectrum.py
+++ b/skypy/galaxy/tests/test_spectrum.py
@@ -4,6 +4,14 @@ import pytest
 from astropy.io.fits import getdata
 
 
+try:
+    import specutils
+except ImportError:
+    SPECUTILS_FOUND = False
+else:
+    SPECUTILS_FOUND = True
+
+
 from skypy.galaxy.spectrum import dirichlet_coefficients, kcorrect_spectra
 
 
@@ -85,10 +93,10 @@ def test_kcorrect_spectra():
     assert np.allclose(sed, templates[0])
 
 
+@pytest.mark.skipif(not SPECUTILS_FOUND, reason='test requires specutils')
 def test_mag_ab_standard_source():
 
     import astropy.units as u
-    import specutils
 
     from skypy.galaxy.spectrum import mag_ab
 
@@ -107,10 +115,10 @@ def test_mag_ab_standard_source():
     assert np.isclose(m, 0)
 
 
+@pytest.mark.skipif(not SPECUTILS_FOUND, reason='test requires specutils')
 def test_mag_ab_redshift_dependence():
 
     import astropy.units as u
-    import specutils
 
     from skypy.galaxy.spectrum import mag_ab
 

--- a/skypy/galaxy/tests/test_spectrum.py
+++ b/skypy/galaxy/tests/test_spectrum.py
@@ -102,7 +102,7 @@ def test_mag_ab_standard_source():
 
     # create a bandpass
     bp_lam = np.logspace(0, 4, 1000)*u.AA
-    bp_tx = np.exp(-((bp_lam - 1000*u.AA)/(100*u.AA))**2)*u.adu
+    bp_tx = np.exp(-((bp_lam - 1000*u.AA)/(100*u.AA))**2)*u.dimensionless_unscaled
     bp = specutils.Spectrum1D(spectral_axis=bp_lam, flux=bp_tx)
 
     # test that the AB standard source has zero magnitude
@@ -124,7 +124,7 @@ def test_mag_ab_redshift_dependence():
 
     # make a wide tophat bandpass
     bp_lam = np.logspace(-10, 10, 3)*u.AA
-    bp_tx = np.ones(3)*u.adu
+    bp_tx = np.ones(3)*u.dimensionless_unscaled
     bp = specutils.Spectrum1D(spectral_axis=bp_lam, flux=bp_tx)
 
     # create a narrow gaussian source

--- a/skypy/galaxy/tests/test_spectrum.py
+++ b/skypy/galaxy/tests/test_spectrum.py
@@ -87,37 +87,48 @@ def test_kcorrect_spectra():
 
 def test_mag_ab_standard_source():
 
+    import astropy.units as u
+    import specutils
+
     from skypy.galaxy.spectrum import mag_ab
 
     # create a bandpass
-    bp_lam = np.logspace(0, 4, 1000)
-    bp_tx = np.exp(-((bp_lam - 1000)/(100))**2)
+    bp_lam = np.logspace(0, 4, 1000)*u.AA
+    bp_tx = np.exp(-((bp_lam - 1000*u.AA)/(100*u.AA))**2)*u.adu
+    bp = specutils.Spectrum1D(spectral_axis=bp_lam, flux=bp_tx)
 
     # test that the AB standard source has zero magnitude
-    lam = np.logspace(0, 4, 1000)
-    flam = 0.10884806248538730623/lam**2
-    m = mag_ab(lam, flam, bp_lam, bp_tx)
+    lam = np.logspace(0, 4, 1000)*u.AA
+    flam = 0.10884806248538730623*u.Unit('erg s-1 cm-2 AA')/lam**2
+    spec = specutils.Spectrum1D(spectral_axis=lam, flux=flam)
+
+    m = mag_ab(spec, bp)
 
     assert np.isclose(m, 0)
 
 
 def test_mag_ab_redshift_dependence():
 
+    import astropy.units as u
+    import specutils
+
     from skypy.galaxy.spectrum import mag_ab
 
     # make a wide tophat bandpass
-    th_lam = np.logspace(-10, 10, 3)
-    th_tx = np.ones(3)
+    bp_lam = np.logspace(-10, 10, 3)*u.AA
+    bp_tx = np.ones(3)*u.adu
+    bp = specutils.Spectrum1D(spectral_axis=bp_lam, flux=bp_tx)
 
     # create a narrow gaussian source
-    lam = np.logspace(0, 3, 1000)
-    flam = np.exp(-((lam - 100)/10)**2)
+    lam = np.logspace(0, 3, 1000)*u.AA
+    flam = np.exp(-((lam - 100*u.AA)/(10*u.AA))**2)*u.Unit('erg s-1 cm-2 AA-1')
+    spec = specutils.Spectrum1D(spectral_axis=lam, flux=flam)
 
     # array of redshifts
     z = np.linspace(0, 1, 11)
 
     # compute the AB magnitude at different redshifts
-    m = mag_ab(lam, flam, th_lam, th_tx, z)
+    m = mag_ab(spec, bp, z)
 
     # compare with expected redshift dependence
     np.testing.assert_allclose(m, m[0] - 2.5*np.log10(1 + z))


### PR DESCRIPTION
## Description

Use `specutils.Spectrum1D` to pass spectrum and bandpass to `skypy.galaxy.spectrum.mag_ab`.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request