### PR TITLE
fix schechter random sampling test failures

### DIFF
--- a/skypy/utils/tests/test_random.py
+++ b/skypy/utils/tests/test_random.py
@@ -43,8 +43,8 @@ def test_schechter_gamma():
 
     from skypy.utils.random import schechter
 
-    # when alpha > -1, x_min ≈ 0, x_max ≈ ∞, distribution is gamma
-    alpha = np.random.uniform(-1, 2)
+    # when alpha > 0, x_min ≈ 0, x_max ≈ ∞, distribution is gamma
+    alpha = np.random.uniform(0, 2)
     x_min = 1e-20
     x_max = 1e+20
     scale = 2.5

--- a/skypy/utils/tests/test_random.py
+++ b/skypy/utils/tests/test_random.py
@@ -44,6 +44,7 @@ def test_schechter_gamma():
     from skypy.utils.random import schechter
 
     # when alpha > 0, x_min ≈ 0, x_max ≈ ∞, distribution is gamma
+    # n.b. if alpha < 0 the distribution becomes too steep to resolve accurately
     alpha = np.random.uniform(0, 2)
     x_min = 1e-20
     x_max = 1e+20


### PR DESCRIPTION
## Description

The tests for `skypy.utils.random.schechter` can fail randomly when the shape parameter `alpha` makes the distribution so steep that the `resolution` is not enough to produce a good sample. This moves the range of `alpha` to where it is less steep so that this should not happen.

## Checklist
- [ ] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [ ] Assign someone from the infrastructure team to review this pull request