### PR TITLE
mag_ab accepts multiple spectra and bandpasses

### DIFF
--- a/skypy/galaxy/spectrum.py
+++ b/skypy/galaxy/spectrum.py
@@ -208,13 +208,11 @@ def mag_ab(spectrum, bandpass, redshift=None):
     r'''Compute absolute AB magnitudes from spectra and bandpasses.
 
     This function takes *emission* spectra and observation bandpasses and
-    computes the AB magnitudes for sources at 10pc (i.e. absolute magnitudes).
+    computes the AB magnitudes.
     The emission spectra can optionally be redshifted. The definition of the
     bandpass AB magnitude is taken from [1]_.
 
-    Both the spectra and the bandpasses must be given as functions of
-    wavelength. The spectra must be given as fluxes with units equivalent to
-    erg/s/cm2/A while the bandpasses should be dimensionless.
+    The bandpasses should have dimensionless `flux` units.
 
     Parameters
     ----------

--- a/skypy/galaxy/spectrum.py
+++ b/skypy/galaxy/spectrum.py
@@ -247,13 +247,14 @@ def mag_ab(spectrum, bandpass, redshift=None):
         redshift = 0.
 
     # Array shapes
-    nz = np.shape(redshift)
+    nz_loop = np.atleast_1d(redshift).shape
     ns_loop = np.atleast_2d(spec_flux).shape[:-1]
     nb_loop = np.atleast_2d(band_tx).shape[:-1]
+    nz_return = np.shape(redshift)
     ns_return = spec_flux.shape[:-1]
     nb_return = band_tx.shape[:-1]
-    loop_shape = (*nz, *nb_loop, *ns_loop)
-    return_shape = (*nz, *nb_return, *ns_return)
+    loop_shape = (*nz_loop, *nb_loop, *ns_loop)
+    return_shape = (*nz_return, *nb_return, *ns_return)
 
     # allocate magnitude array
     mag_ab = np.empty(loop_shape, dtype=float)
@@ -268,12 +269,12 @@ def mag_ab(spectrum, bandpass, redshift=None):
     spec_intg = spec_lam*spec_flux
 
     # go through redshifts ...
-    for i, z in np.ndenumerate(redshift):
+    for i, z in enumerate(np.atleast_1d(redshift)):
 
         # observed wavelength of spectrum
         obs_lam = (1 + z)*spec_lam
 
-        for j, b in np.atleast2d(band_tx):
+        for j, b in enumerate(np.atleast_2d(band_tx)):
 
             # interpolate band to get transmission at observed wavelengths
             obs_tx = np.interp(obs_lam, band_lam, b, left=0, right=0)

--- a/skypy/galaxy/spectrum.py
+++ b/skypy/galaxy/spectrum.py
@@ -205,37 +205,37 @@ def kcorrect_spectra(redshift, stellar_mass, coefficients):
 
 
 def mag_ab(spectrum, bandpass, redshift=None):
-    r'''Compute absolute AB magnitude from spectrum and bandpass.
+    r'''Compute absolute AB magnitudes from spectra and bandpasses.
 
-    This function takes an *emission* spectrum and an observation bandpass and
-    computes the AB magnitude for a source at 10pc (i.e. absolute magnitude).
-    The emission spectrum can optionally be redshifted. The definition of the
+    This function takes *emission* spectra and observation bandpasses and
+    computes the AB magnitudes for sources at 10pc (i.e. absolute magnitudes).
+    The emission spectra can optionally be redshifted. The definition of the
     bandpass AB magnitude is taken from [1]_.
 
-    Both the spectrum and the bandpass must be given as functions of wavelength
-    in Angstrom. The spectrum must be given as flux in erg/s/cm2/A.
+    Both the spectra and the bandpasses must be given as functions of
+    wavelength. The spectra must be given as fluxes with units equivalent to
+    erg/s/cm2/A while the bandpasses should be dimensionless.
 
     Parameters
     ----------
     spectrum : specutils.Spectrum1D
-        Emission spectrum of the source.
+        Emission spectra of the sources.
     bandpass : specutils.Spectrum1D
-        Bandpass filter.
-    redshift : array_like, optional
-        Optional array of values for redshifting the source spectrum.
+        Bandpass filters.
+    redshift : (nz,) array_like, optional
+        Optional array of values for redshifting the source spectra.
 
     Returns
     -------
-    mag_ab : array_like
-        The absolute AB magnitude. If redshifts are given, the output has the
-        same shape as the `redshift` argument.
+    mag_ab : (nz, nb, ns) array_like
+        Absolute AB magnitudes.
 
     References
     ----------
     .. [1] M. R. Blanton et al., 2003, AJ, 125, 2348
     '''
 
-    # get the spectrum and bandpass
+    # get the spectra and bandpasses
     spec_lam = spectrum.wavelength.to_value(units.AA, equivalencies=units.spectral())
     spec_flux = spectrum.flux.to_value('erg s-1 cm-2 AA-1',
                                        equivalencies=units.spectral_density(spec_lam))
@@ -271,7 +271,7 @@ def mag_ab(spectrum, bandpass, redshift=None):
     # go through redshifts ...
     for i, z in enumerate(np.atleast_1d(redshift)):
 
-        # observed wavelength of spectrum
+        # observed wavelength of spectra
         obs_lam = (1 + z)*spec_lam
 
         for j, b in enumerate(np.atleast_2d(band_tx)):

--- a/skypy/galaxy/spectrum.py
+++ b/skypy/galaxy/spectrum.py
@@ -208,11 +208,9 @@ def mag_ab(spectrum, bandpass, redshift=None):
     r'''Compute absolute AB magnitudes from spectra and bandpasses.
 
     This function takes *emission* spectra and observation bandpasses and
-    computes the AB magnitudes.
-    The emission spectra can optionally be redshifted. The definition of the
-    bandpass AB magnitude is taken from [1]_.
-
-    The bandpasses should have dimensionless `flux` units.
+    computes the AB magnitudes. The definition of the bandpass AB magnitude is
+    taken from [1]_. The emission spectra can optionally be redshifted and the
+    bandpasses should have dimensionless `flux` units.
 
     Parameters
     ----------

--- a/skypy/galaxy/spectrum.py
+++ b/skypy/galaxy/spectrum.py
@@ -283,6 +283,6 @@ def mag_ab(spectrum, bandpass, redshift=None):
             mag_ab[i, j, :] = -2.5*np.log10(np.trapz(spec_intg*obs_tx, obs_lam))
 
     # combine AB magnitude [all of (2)]
-    mag_ab += m_offs
+    mag_ab += np.atleast_1d(m_offs)[:, np.newaxis]
 
     return mag_ab.item() if not return_shape else mag_ab.reshape(return_shape)


### PR DESCRIPTION
## Description
[specutils.Spectrum1D](https://specutils.readthedocs.io/en/stable/api/specutils.Spectrum1D.html#specutils.Spectrum1D) can contain multiple spectra that share the same `spectral_axis`. In this PR `mag_ab` now checks its arguments for multiple spectra and bandpasses and calculates the magnitudes for each spectrum at each redshift in each bandpass.

Note that this function will calculate the magnitude of each spectrum at every redshift. It cannot calculate the magnitude of the spectra each at a unique redshift.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
