### PR TITLE
mark kstests as flaky with 3 reruns

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,8 @@ Before your pull request can be merged into the codebase, it will be reviewed by
 
 Pull requests will require existing unit tests to pass before they can be merged. Additionally, new unit tests should be written for all new public methods and functions. Unit tests for each submodule are contained in subdirectories called `tests` and you can run them locally using `pytest`. For more information see the [Astropy Testing Guidelines](https://docs.astropy.org/en/stable/development/testguide.html).
 
+If your unit tests check the statistical distribution of a random sample, the test outcome itself is a random variable, and the test will fail from time to time. Please mark such tests with the `@pytest.mark.flaky(reruns=3)` decorator, so that they will be automatically tried up to 3 times. To prevent non-random test failures from being run multiple times, please isolate random statistical tests and deterministic tests in their own test cases.
+
 ### Docstrings
 
 All public classes, methods and functions require docstrings. You can build documentation locally by installing [sphinx-astropy](https://github.com/astropy/sphinx-astropy) and calling `make html` in the `docs` subdirectory. Docstrings should include the following sections:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,7 +124,7 @@ Before your pull request can be merged into the codebase, it will be reviewed by
 
 Pull requests will require existing unit tests to pass before they can be merged. Additionally, new unit tests should be written for all new public methods and functions. Unit tests for each submodule are contained in subdirectories called `tests` and you can run them locally using `pytest`. For more information see the [Astropy Testing Guidelines](https://docs.astropy.org/en/stable/development/testguide.html).
 
-If your unit tests check the statistical distribution of a random sample, the test outcome itself is a random variable, and the test will fail from time to time. Please mark such tests with the `@pytest.mark.flaky(reruns=3)` decorator, so that they will be automatically tried up to 3 times. To prevent non-random test failures from being run multiple times, please isolate random statistical tests and deterministic tests in their own test cases.
+If your unit tests check the statistical distribution of a random sample, the test outcome itself is a random variable, and the test will fail from time to time. Please mark such tests with the `@pytest.mark.flaky` decorator, so that they will be automatically tried again on failure. To prevent non-random test failures from being run multiple times, please isolate random statistical tests and deterministic tests in their own test cases.
 
 ### Docstrings
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ console_scripts =
 [options.extras_require]
 test =
     pytest-astropy
+    pytest-rerunfailures
     specutils
 all =
     camb

--- a/skypy/galaxy/tests/test_ellipticity.py
+++ b/skypy/galaxy/tests/test_ellipticity.py
@@ -3,7 +3,7 @@ import pytest
 from scipy import stats
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky
 def test_beta_ellipticity():
 
     from skypy.galaxy.ellipticity import beta_ellipticity

--- a/skypy/galaxy/tests/test_ellipticity.py
+++ b/skypy/galaxy/tests/test_ellipticity.py
@@ -1,7 +1,9 @@
 import numpy as np
+import pytest
 from scipy import stats
 
 
+@pytest.mark.flaky(reruns=3)
 def test_beta_ellipticity():
 
     from skypy.galaxy.ellipticity import beta_ellipticity

--- a/skypy/galaxy/tests/test_luminosity.py
+++ b/skypy/galaxy/tests/test_luminosity.py
@@ -1,7 +1,9 @@
 import numpy as np
+import pytest
 from scipy.stats import kstest
 
 
+@pytest.mark.flaky(reruns=3)
 def test_schechter_lf_magnitude():
     from skypy.galaxy.luminosity import schechter_lf_magnitude
     from astropy.cosmology import default_cosmology

--- a/skypy/galaxy/tests/test_luminosity.py
+++ b/skypy/galaxy/tests/test_luminosity.py
@@ -3,7 +3,7 @@ import pytest
 from scipy.stats import kstest
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky
 def test_schechter_lf_magnitude():
     from skypy.galaxy.luminosity import schechter_lf_magnitude
     from astropy.cosmology import default_cosmology

--- a/skypy/galaxy/tests/test_redshift.py
+++ b/skypy/galaxy/tests/test_redshift.py
@@ -3,7 +3,7 @@ import pytest
 from scipy.stats import kstest
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky
 def test_schechter_lf_redshift():
 
     from skypy.galaxy.redshift import schechter_lf_redshift, redshifts_from_comoving_density
@@ -53,7 +53,7 @@ def test_schechter_lf_redshift():
     assert p > 0.01, 'D = {}, p = {}'.format(D, p)
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky
 def test_redshifts_from_comoving_density():
 
     from skypy.galaxy.redshift import redshifts_from_comoving_density
@@ -83,7 +83,7 @@ def test_redshifts_from_comoving_density():
     assert p > 0.01, 'D = {}, p = {}'.format(D, p)
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky
 def test_smail():
     from skypy.galaxy.redshift import smail
 

--- a/skypy/galaxy/tests/test_redshift.py
+++ b/skypy/galaxy/tests/test_redshift.py
@@ -1,8 +1,9 @@
 import numpy as np
-
+import pytest
 from scipy.stats import kstest
 
 
+@pytest.mark.flaky(reruns=3)
 def test_schechter_lf_redshift():
 
     from skypy.galaxy.redshift import schechter_lf_redshift, redshifts_from_comoving_density
@@ -52,6 +53,7 @@ def test_schechter_lf_redshift():
     assert p > 0.01, 'D = {}, p = {}'.format(D, p)
 
 
+@pytest.mark.flaky(reruns=3)
 def test_redshifts_from_comoving_density():
 
     from skypy.galaxy.redshift import redshifts_from_comoving_density
@@ -81,6 +83,7 @@ def test_redshifts_from_comoving_density():
     assert p > 0.01, 'D = {}, p = {}'.format(D, p)
 
 
+@pytest.mark.flaky(reruns=3)
 def test_smail():
     from skypy.galaxy.redshift import smail
 

--- a/skypy/galaxy/tests/test_schechter.py
+++ b/skypy/galaxy/tests/test_schechter.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from scipy.stats import kstest
 
 

--- a/skypy/galaxy/tests/test_size.py
+++ b/skypy/galaxy/tests/test_size.py
@@ -28,6 +28,7 @@ def test_angular_size():
         size.angular_size(radius_without_units, scalar_redshift, cosmology)
 
 
+@pytest.mark.flaky(reruns=3)
 def test_late_type_lognormal():
     """ Test lognormal distribution of late-type galaxy sizes"""
     # Test that a scalar input gives a scalar output
@@ -69,6 +70,7 @@ def test_late_type_lognormal():
     assert p > 0.01
 
 
+@pytest.mark.flaky(reruns=3)
 def test_early_type_lognormal():
     """ Test lognormal distribution of late-type galaxy sizes"""
     # Test that a scalar input gives a scalar output
@@ -107,6 +109,7 @@ def test_early_type_lognormal():
     assert p > 0.01
 
 
+@pytest.mark.flaky(reruns=3)
 def test_linear_lognormal():
     """ Test lognormal distribution of galaxy sizes"""
     # Test that a scalar input gives a scalar output

--- a/skypy/galaxy/tests/test_size.py
+++ b/skypy/galaxy/tests/test_size.py
@@ -28,7 +28,7 @@ def test_angular_size():
         size.angular_size(radius_without_units, scalar_redshift, cosmology)
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky
 def test_late_type_lognormal():
     """ Test lognormal distribution of late-type galaxy sizes"""
     # Test that a scalar input gives a scalar output
@@ -70,7 +70,7 @@ def test_late_type_lognormal():
     assert p > 0.01
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky
 def test_early_type_lognormal():
     """ Test lognormal distribution of late-type galaxy sizes"""
     # Test that a scalar input gives a scalar output
@@ -109,7 +109,7 @@ def test_early_type_lognormal():
     assert p > 0.01
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky
 def test_linear_lognormal():
     """ Test lognormal distribution of galaxy sizes"""
     # Test that a scalar input gives a scalar output

--- a/skypy/galaxy/tests/test_spectrum.py
+++ b/skypy/galaxy/tests/test_spectrum.py
@@ -15,6 +15,7 @@ else:
 from skypy.galaxy.spectrum import dirichlet_coefficients, kcorrect_spectra
 
 
+@pytest.mark.flaky(reruns=3)
 def test_sampling_coefficients():
     alpha0 = np.array([2.079, 3.524, 1.917, 1.992, 2.536])
     alpha1 = np.array([2.265, 3.862, 1.921, 1.685, 2.480])

--- a/skypy/galaxy/tests/test_spectrum.py
+++ b/skypy/galaxy/tests/test_spectrum.py
@@ -15,7 +15,7 @@ else:
 from skypy.galaxy.spectrum import dirichlet_coefficients, kcorrect_spectra
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky
 def test_sampling_coefficients():
     alpha0 = np.array([2.079, 3.524, 1.917, 1.992, 2.536])
     alpha1 = np.array([2.265, 3.862, 1.921, 1.685, 2.480])

--- a/skypy/galaxy/tests/test_stellar_mass.py
+++ b/skypy/galaxy/tests/test_stellar_mass.py
@@ -8,6 +8,7 @@ from skypy.galaxy import stellar_mass
 from skypy.utils import special
 
 
+@pytest.mark.flaky(reruns=3)
 def test_exponential_distribution():
     # When alpha=0, M*=1 and x_min~0 we get a truncated exponential
     q_max = 1e2
@@ -18,6 +19,7 @@ def test_exponential_distribution():
     assert p_value >= 0.01
 
 
+@pytest.mark.flaky(reruns=3)
 def test_stellar_masses():
     # Test that error is returned if m_star input is an array but size !=
     # None and size != m_star,size

--- a/skypy/galaxy/tests/test_stellar_mass.py
+++ b/skypy/galaxy/tests/test_stellar_mass.py
@@ -8,7 +8,7 @@ from skypy.galaxy import stellar_mass
 from skypy.utils import special
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky
 def test_exponential_distribution():
     # When alpha=0, M*=1 and x_min~0 we get a truncated exponential
     q_max = 1e2
@@ -19,7 +19,7 @@ def test_exponential_distribution():
     assert p_value >= 0.01
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky
 def test_stellar_masses():
     # Test that error is returned if m_star input is an array but size !=
     # None and size != m_star,size

--- a/skypy/position/tests/test_uniform.py
+++ b/skypy/position/tests/test_uniform.py
@@ -1,8 +1,9 @@
 import numpy as np
-
+import pytest
 from scipy.stats import kstest
 
 
+@pytest.mark.flaky(reruns=3)
 def test_uniform_around():
     from skypy.position import uniform_around
     from astropy.coordinates import SkyCoord

--- a/skypy/position/tests/test_uniform.py
+++ b/skypy/position/tests/test_uniform.py
@@ -3,7 +3,7 @@ import pytest
 from scipy.stats import kstest
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky
 def test_uniform_around():
     from skypy.position import uniform_around
     from astropy.coordinates import SkyCoord

--- a/skypy/utils/tests/test_random.py
+++ b/skypy/utils/tests/test_random.py
@@ -1,8 +1,9 @@
 import numpy as np
-
+import pytest
 from scipy.stats import kstest
 
 
+@pytest.mark.flaky(reruns=3)
 def test_schechter():
 
     from skypy.utils.random import schechter
@@ -39,6 +40,7 @@ def test_schechter():
     assert np.shape(samples) == np.shape(scale)
 
 
+@pytest.mark.flaky(reruns=3)
 def test_schechter_gamma():
 
     from skypy.utils.random import schechter

--- a/skypy/utils/tests/test_random.py
+++ b/skypy/utils/tests/test_random.py
@@ -3,7 +3,7 @@ import pytest
 from scipy.stats import kstest
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky
 def test_schechter():
 
     from skypy.utils.random import schechter
@@ -40,7 +40,7 @@ def test_schechter():
     assert np.shape(samples) == np.shape(scale)
 
 
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky
 def test_schechter_gamma():
 
     from skypy.utils.random import schechter


### PR DESCRIPTION
## Description

Failing random tests are retested automatically. All future random tests must be marked `@pytest.mark.flaky` as appropriate. Ideally, future distribution test cases should contain only a single test so that non-random failures are not retried.

## Checklist
- [ ] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [ ] Assign someone from the infrastructure team to review this pull request