### PR TITLE
pin pytest<6.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ console_scripts =
 
 [options.extras_require]
 test =
+    pytest<6.1
     pytest-astropy
     pytest-rerunfailures
     specutils


### PR DESCRIPTION
## Description

Pin pytest to below 6.1 until pytest-dev/pytest-rerunfailures#128 is sorted out.

## Checklist
- [ ] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [ ] Assign someone from the infrastructure team to review this pull request
