### PR TITLE
Pipeline: load functions from string on construction

### DIFF
--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -17,26 +17,40 @@ __all__ = [
 ]
 
 
-def _yaml_tag(loader, tag, node):
-    '''handler for generic YAML tags
+def import_function(qualname):
+    '''load function from fully qualified name'''
+    path = qualname.split('.')
+    module = builtins
+    for i, key in enumerate(path[:-1]):
+        if not hasattr(module, key):
+            module = import_module('.'.join(path[:i+1]))
+        else:
+            module = getattr(module, key)
+    function = getattr(module, path[-1])
+    return function
 
-    tags are stored as a tuple `(tag, value)`
+
+def function_tag(loader, name, node):
+    '''load function from !function tag
+
+    tags are stored as a tuple `(function, args)`
     '''
 
     import yaml
 
     if isinstance(node, yaml.ScalarNode):
-        value = loader.construct_scalar(node)
+        args = loader.construct_scalar(node)
     elif isinstance(node, yaml.SequenceNode):
-        value = loader.construct_sequence(node)
+        args = loader.construct_sequence(node)
     elif isinstance(node, yaml.MappingNode):
-        value = loader.construct_mapping(node)
+        args = loader.construct_mapping(node)
 
-    # tags without arguments have empty string value
-    if value == '':
-        return tag,
+    try:
+        function = import_function(name)
+    except (ModuleNotFoundError, AttributeError) as e:  # pragma: no cover
+        raise ImportError(f'{e}\n{node.start_mark}') from e
 
-    return tag, value
+    return (function,) if args == '' else (function, args)
 
 
 class Pipeline:
@@ -59,7 +73,7 @@ class Pipeline:
         import yaml
 
         # register custom tags
-        yaml.SafeLoader.add_multi_constructor('!', _yaml_tag)
+        yaml.SafeLoader.add_multi_constructor('!', function_tag)
 
         # read the file
         with open(filename, 'r') as stream:
@@ -81,14 +95,12 @@ class Pipeline:
         Each step in the pipeline is configured by a dictionary specifying
         a variable name and the associated value.
 
-        A value that is a tuple `(function_name, function_args)` specifies that
-        the value will be the result of a function call. The first item is the
-        fully qualified function name, and the second value specifies the
-        function arguments.
+        A value that is a tuple `(function, args)` specifies that the value will
+        be the result of a function call. The first item is a callable, and the
+        second value specifies the function arguments.
 
-        If a function argument is a tuple `(variable_name,)`, it refers to the
-        values of previous step in the pipeline. The tuple item must be the
-        name of the reference variable.
+        If a function argument is a string `$variable_name`, it refers to the
+        values of previous step in the pipeline.
 
         'configuration' should contain the name and configuration of each
         variable and/or an entry named 'tables'. 'tables' should contain a set
@@ -112,7 +124,7 @@ class Pipeline:
         self.cosmology = self.config.pop('cosmology', {})
         self.parameters = self.config.pop('parameters', {})
         self.table_config = self.config.pop('tables', {})
-        default_table = ('astropy.table.Table',)
+        default_table = (Table,)
         self.config.update({k: v.pop('.init', default_table)
                             for k, v in self.table_config.items()})
 
@@ -260,23 +272,9 @@ class Pipeline:
                 # plain value
                 return value
 
-        # value is tuple (function name, [function args])
-        name = value[0]
+        # value is tuple (function, [args])
+        function = value[0]
         args = value[1] if len(value) > 1 else []
-
-        # Import function
-        function_path = name.split('.')
-        module = builtins
-        for i, key in enumerate(function_path[:-1]):
-            if not hasattr(module, key):
-                module_name = '.'.join(function_path[:i+1])
-                try:
-                    module = import_module(module_name)
-                except ModuleNotFoundError:
-                    raise ModuleNotFoundError(module_name)
-            else:
-                module = getattr(module, key)
-        function = getattr(module, function_path[-1])
 
         # Parse arguments
         parsed_args = self.get_args(args)


### PR DESCRIPTION
## Description

Since the function lookup from string incurs a massive overhead when running the pipeline repeatedly, the construction is done only when YAML is parsed, and function objects are stored in the config.

Added benefit: We can raise a useful `ImportError` if a function does not exist:

```
ImportError: module 'astropy.modeling.models' has no attribute 'Linear1'
  in "examples/mccl_galaxies.yml", line 7, column 13
```

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request