### PR TITLE
Revert "pin pytest<6.1 (#295)"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ console_scripts =
 
 [options.extras_require]
 test =
-    pytest<6.1
     pytest-astropy
     pytest-rerunfailures
     specutils


### PR DESCRIPTION
## Description

A fixed version of pytest-rerunfailures has been released so this reverts the no longer necessary pytest pin from #295.

## Checklist
- [ ] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [ ] Assign someone from the infrastructure team to review this pull request
