### PR TITLE
remove stellar mass units

### DIFF
--- a/skypy/galaxy/spectrum.py
+++ b/skypy/galaxy/spectrum.py
@@ -223,7 +223,7 @@ def magnitudes_from_templates(coefficients, templates, bandpass, redshift=None,
         the number of objects is less than resolution their magnitudes are
         calculated directly without interpolation.
     stellar_mass : (ng,) array_like, optional
-        Optional array of stellar masses for each galaxy in units of Msun.
+        Optional array of stellar masses for each galaxy in template units.
     distance_modulus : (ng,) array_like, optional
         Optional array of distance moduli for each galaxy.
 
@@ -261,7 +261,7 @@ def magnitudes_from_templates(coefficients, templates, bandpass, redshift=None,
     else:
         M = mag_ab(templates, bandpass, redshift).reshape(M_shape)
 
-    stellar_mass = 1 if stellar_mass is None else stellar_mass.to_value(units.Msun)
+    stellar_mass = 1 if stellar_mass is None else stellar_mass
     distance_modulus = 0 if distance_modulus is None else distance_modulus
 
     flux = np.sum(coefficients[:, np.newaxis, :] * np.power(10, -0.4*M), axis=2)
@@ -295,12 +295,12 @@ def stellar_mass_from_reference_band(coefficients, templates, magnitudes, bandpa
     Returns
     -------
     stellar_mass : (ng,) array_like
-        Stellar mass of each galaxy in solar masses.
+        Stellar mass of each galaxy in template units.
     '''
 
     flux = np.power(10, -0.4 * mag_ab(templates, bandpass))
     stellar_mass = np.power(10, -0.4*magnitudes) / np.sum(coefficients * flux, axis=1)
-    return stellar_mass * units.Msun
+    return stellar_mass
 
 
 def load_spectral_data(name):

--- a/skypy/galaxy/tests/test_spectrum.py
+++ b/skypy/galaxy/tests/test_spectrum.py
@@ -179,9 +179,9 @@ def test_template_spectra():
     np.testing.assert_allclose(mt, m + dm)
 
     # Test stellar mass
-    sm = np.array([1, 2, 3]) * units.Msun
+    sm = np.array([1, 2, 3])
     mt = magnitudes_from_templates(coefficients, spec, bp, stellar_mass=sm)
-    np.testing.assert_allclose(mt, m - 2.5*np.log10(sm.to_value('Msun')))
+    np.testing.assert_allclose(mt, m - 2.5*np.log10(sm))
 
     # Redshift interpolation test; linear interpolation sufficient over a small
     # redshift range at low relative tolerance
@@ -221,13 +221,13 @@ def test_stellar_mass_from_reference_band():
     # Using the absolute magnitudes of the templates as reference magnitudes
     # should return one solar mass for each template.
     stellar_mass = stellar_mass_from_reference_band(coeff, templates, Mt, band)
-    truth = 1 * units.Msun
+    truth = 1
     np.testing.assert_allclose(stellar_mass, truth)
 
     # Solution for given magnitudes without template mixing
     Mb = np.array([10, 20, 30])
     stellar_mass = stellar_mass_from_reference_band(coeff, templates, Mb, band)
-    truth = np.power(10, -0.4*(Mb-Mt)) * units.Msun
+    truth = np.power(10, -0.4*(Mb-Mt))
     np.testing.assert_allclose(stellar_mass, truth)
 
 


### PR DESCRIPTION
## Description

Remove units from stellar mass input/output because our driver passes Column, not Quantity, to functions:

```
skypy/galaxy/spectrum.py in magnitudes_from_templates(coefficients, templates, bandpass, redshift, resolution, stellar_mass, distance_modulus)
    262         M = mag_ab(templates, bandpass, redshift).reshape(M_shape)
    263 
--> 264     stellar_mass = 1 if stellar_mass is None else stellar_mass.to_value(units.Msun)
    265     distance_modulus = 0 if distance_modulus is None else distance_modulus
    266 

AttributeError: 'Column' object has no attribute 'to_value'
```

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request