### PR TITLE
Use default cosmology context in pipeline

### DIFF
--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -128,6 +128,11 @@ class Pipeline:
         # - keep track where functions need to be called
         #   functions are tuples (function name, [function args])
         functions = {}
+        for job in self.parameters:
+            self.dag.add_node(job)
+            self.skip_jobs.add(job)
+        self.dag.add_node('cosmology')
+        self.skip_jobs.add('cosmology')
         for job, settings in self.config.items():
             self.dag.add_node(job)
             if isinstance(settings, tuple):

--- a/skypy/pipeline/tests/test_pipeline.py
+++ b/skypy/pipeline/tests/test_pipeline.py
@@ -169,6 +169,9 @@ def test_multi_column_assignment_failure(na, nt):
 
 def test_pipeline_cosmology():
 
+    # Initial default_cosmology
+    initial_default = default_cosmology.get()
+
     # Test pipeline correctly sets default cosmology from parameters
     from astropy.cosmology import FlatLambdaCDM
     H0, Om0 = 70, 0.3
@@ -189,8 +192,8 @@ def test_pipeline_cosmology():
     assert pipeline['test'].H0.value == H0_new
     assert pipeline['test'].Om0 == Om0_new
 
-
-
+    # Check that the astropy default cosmology is unchanged
+    assert default_cosmology.get() == initial_default
 
 
 def teardown_module(module):

--- a/skypy/pipeline/tests/test_pipeline.py
+++ b/skypy/pipeline/tests/test_pipeline.py
@@ -173,6 +173,7 @@ def test_pipeline_cosmology():
     initial_default = default_cosmology.get()
 
     # Test pipeline correctly sets default cosmology from parameters
+    # N.B. astropy cosmology class has not implemented __eq__ for comparison
     from astropy.cosmology import FlatLambdaCDM
     H0, Om0 = 70, 0.3
     config = {'parameters': {'H0': H0, 'Om0': Om0},


### PR DESCRIPTION
## Description
Pipeline now sets `parameters` and `cosmology` before executing all other jobs in the DAG. The DAG is also resolved using the `default_cosmology.set()` context so that all functions decorated with `@uses_default_cosmology` will use the cosmology defined in the config (or the astropy default cosmology if undefined). Note that currently `cosmology` can only depend on values in parameters and not any other variables defined in the config file. Resolves #293 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
