### PR TITLE
Config parser

### DIFF
--- a/skypy/pipeline/__init__.py
+++ b/skypy/pipeline/__init__.py
@@ -3,4 +3,5 @@ This module provides methods to pipeline together multiple models with
 dependencies and handle their outputs.
 """
 
+from ._config import *  # noqa
 from ._pipeline import *  # noqa

--- a/skypy/pipeline/_config.py
+++ b/skypy/pipeline/_config.py
@@ -1,0 +1,39 @@
+import yaml
+
+__all__ = [
+    'skypy_config',
+]
+
+
+def _yaml_tag(loader, tag, node):
+    '''handler for generic YAML tags
+
+    tags are stored as a tuple `(tag, value)`
+    '''
+
+    if isinstance(node, yaml.ScalarNode):
+        value = loader.construct_scalar(node)
+    elif isinstance(node, yaml.SequenceNode):
+        value = loader.construct_sequence(node)
+    elif isinstance(node, yaml.MappingNode):
+        value = loader.construct_mapping(node)
+
+    # tags without arguments have empty string value
+    if value == '':
+        return tag,
+
+    return tag, value
+
+
+def skypy_config(filename):
+    '''Read a SkyPy pipeline configuration from a YAML file.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the configuration file.
+    '''
+
+    yaml.SafeLoader.add_multi_constructor('!', _yaml_tag)
+    with open(filename, 'r') as stream:
+        return yaml.safe_load(stream) or {}

--- a/skypy/pipeline/_config.py
+++ b/skypy/pipeline/_config.py
@@ -35,7 +35,7 @@ def function_tag(loader, name, node):
 
     try:
         function = import_function(name)
-    except (ModuleNotFoundError, AttributeError) as e:  # pragma: no cover
+    except (ModuleNotFoundError, AttributeError) as e:
         raise ImportError(f'{e}\n{node.start_mark}') from e
 
     return (function,) if args == '' else (function, args)

--- a/skypy/pipeline/_config.py
+++ b/skypy/pipeline/_config.py
@@ -3,7 +3,7 @@ from importlib import import_module
 import yaml
 
 __all__ = [
-    'skypy_config',
+    'load_skypy_yaml',
 ]
 
 
@@ -41,7 +41,7 @@ def function_tag(loader, name, node):
     return (function,) if args == '' else (function, args)
 
 
-def skypy_config(filename):
+def load_skypy_yaml(filename):
     '''Read a SkyPy pipeline configuration from a YAML file.
 
     Parameters

--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -7,51 +7,13 @@ and handle their results.
 from astropy.cosmology import default_cosmology
 from astropy.table import Table
 from copy import copy, deepcopy
-from importlib import import_module
 from skypy.pipeline import skypy_config
-import builtins
 import networkx
 
 
 __all__ = [
     'Pipeline',
 ]
-
-
-def import_function(qualname):
-    '''load function from fully qualified name'''
-    path = qualname.split('.')
-    module = builtins
-    for i, key in enumerate(path[:-1]):
-        if not hasattr(module, key):
-            module = import_module('.'.join(path[:i+1]))
-        else:
-            module = getattr(module, key)
-    function = getattr(module, path[-1])
-    return function
-
-
-def function_tag(loader, name, node):
-    '''load function from !function tag
-
-    tags are stored as a tuple `(function, args)`
-    '''
-
-    import yaml
-
-    if isinstance(node, yaml.ScalarNode):
-        args = loader.construct_scalar(node)
-    elif isinstance(node, yaml.SequenceNode):
-        args = loader.construct_sequence(node)
-    elif isinstance(node, yaml.MappingNode):
-        args = loader.construct_mapping(node)
-
-    try:
-        function = import_function(name)
-    except (ModuleNotFoundError, AttributeError) as e:  # pragma: no cover
-        raise ImportError(f'{e}\n{node.start_mark}') from e
-
-    return (function,) if args == '' else (function, args)
 
 
 class Pipeline:

--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -8,6 +8,7 @@ from astropy.cosmology import default_cosmology
 from astropy.table import Table
 from copy import copy, deepcopy
 from importlib import import_module
+from skypy.pipeline import skypy_config
 import builtins
 import networkx
 
@@ -15,28 +16,6 @@ import networkx
 __all__ = [
     'Pipeline',
 ]
-
-
-def _yaml_tag(loader, tag, node):
-    '''handler for generic YAML tags
-
-    tags are stored as a tuple `(tag, value)`
-    '''
-
-    import yaml
-
-    if isinstance(node, yaml.ScalarNode):
-        value = loader.construct_scalar(node)
-    elif isinstance(node, yaml.SequenceNode):
-        value = loader.construct_sequence(node)
-    elif isinstance(node, yaml.MappingNode):
-        value = loader.construct_mapping(node)
-
-    # tags without arguments have empty string value
-    if value == '':
-        return tag,
-
-    return tag, value
 
 
 class Pipeline:
@@ -56,16 +35,7 @@ class Pipeline:
             The name of the configuration file.
 
         '''
-        import yaml
-
-        # register custom tags
-        yaml.SafeLoader.add_multi_constructor('!', _yaml_tag)
-
-        # read the file
-        with open(filename, 'r') as stream:
-            config = yaml.safe_load(stream) or {}
-
-        # construct the pipeline
+        config = skypy_config(filename)
         return cls(config)
 
     def __init__(self, configuration):

--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -7,7 +7,7 @@ and handle their results.
 from astropy.cosmology import default_cosmology
 from astropy.table import Table
 from copy import copy, deepcopy
-from skypy.pipeline import skypy_config
+from ._config import load_skypy_yaml
 import networkx
 
 
@@ -33,7 +33,7 @@ class Pipeline:
             The name of the configuration file.
 
         '''
-        config = skypy_config(filename)
+        config = load_skypy_yaml(filename)
         return cls(config)
 
     def __init__(self, configuration):

--- a/skypy/pipeline/tests/data/bad_function.yml
+++ b/skypy/pipeline/tests/data/bad_function.yml
@@ -1,0 +1,1 @@
+test: !builtins.nofunction

--- a/skypy/pipeline/tests/data/bad_module.yml
+++ b/skypy/pipeline/tests/data/bad_module.yml
@@ -1,0 +1,1 @@
+test: !nomodule.function

--- a/skypy/pipeline/tests/test_config.py
+++ b/skypy/pipeline/tests/test_config.py
@@ -1,18 +1,18 @@
 from astropy.utils.data import get_pkg_data_filename
 from collections.abc import Callable
 import pytest
-from skypy.pipeline import skypy_config
+from skypy.pipeline import load_skypy_yaml
 
 
-def test_config():
+def test_load_skypy_yaml():
 
     # Read empty config file
     filename = get_pkg_data_filename('data/empty_config.yml')
-    assert skypy_config(filename) == {}
+    assert load_skypy_yaml(filename) == {}
 
     # Read config file and check entries are parsed to the correct types
     filename = get_pkg_data_filename('data/test_config.yml')
-    config = skypy_config(filename)
+    config = load_skypy_yaml(filename)
     assert isinstance(config['test_int'], int)
     assert isinstance(config['test_float'], float)
     assert isinstance(config['test_str'], str)
@@ -25,9 +25,9 @@ def test_config():
     # Bad function
     filename = get_pkg_data_filename('data/bad_function.yml')
     with pytest.raises(ImportError):
-        skypy_config(filename)
+        load_skypy_yaml(filename)
 
     # Bad module
     filename = get_pkg_data_filename('data/bad_module.yml')
     with pytest.raises(ImportError):
-        skypy_config(filename)
+        load_skypy_yaml(filename)

--- a/skypy/pipeline/tests/test_config.py
+++ b/skypy/pipeline/tests/test_config.py
@@ -1,4 +1,5 @@
 from astropy.utils.data import get_pkg_data_filename
+from collections.abc import Callable
 import pytest
 from skypy.pipeline import skypy_config
 
@@ -16,7 +17,9 @@ def test_config():
     assert isinstance(config['test_float'], float)
     assert isinstance(config['test_str'], str)
     assert isinstance(config['test_func'], tuple)
+    assert isinstance(config['test_cosmology'][0], Callable)
     assert isinstance(config['test_cosmology'][1], dict)
+    assert isinstance(config['tables']['test_table_1']['test_column_3'][0], Callable)
     assert isinstance(config['tables']['test_table_1']['test_column_3'][1], list)
 
     # Bad function

--- a/skypy/pipeline/tests/test_config.py
+++ b/skypy/pipeline/tests/test_config.py
@@ -1,0 +1,19 @@
+from astropy.utils.data import get_pkg_data_filename
+from skypy.pipeline import skypy_config
+
+
+def test_config():
+
+    # Read empty config file
+    filename = get_pkg_data_filename('data/empty_config.yml')
+    assert skypy_config(filename) == {}
+
+    # Read config file and check entries are parsed to the correct types
+    filename = get_pkg_data_filename('data/test_config.yml')
+    config = skypy_config(filename)
+    assert isinstance(config['test_int'], int)
+    assert isinstance(config['test_float'], float)
+    assert isinstance(config['test_str'], str)
+    assert isinstance(config['test_func'], tuple)
+    assert isinstance(config['test_cosmology'][1], dict)
+    assert isinstance(config['tables']['test_table_1']['test_column_3'][1], list)

--- a/skypy/pipeline/tests/test_config.py
+++ b/skypy/pipeline/tests/test_config.py
@@ -1,4 +1,5 @@
 from astropy.utils.data import get_pkg_data_filename
+import pytest
 from skypy.pipeline import skypy_config
 
 
@@ -17,3 +18,13 @@ def test_config():
     assert isinstance(config['test_func'], tuple)
     assert isinstance(config['test_cosmology'][1], dict)
     assert isinstance(config['tables']['test_table_1']['test_column_3'][1], list)
+
+    # Bad function
+    filename = get_pkg_data_filename('data/bad_function.yml')
+    with pytest.raises(ImportError):
+        skypy_config(filename)
+
+    # Bad module
+    filename = get_pkg_data_filename('data/bad_module.yml')
+    with pytest.raises(ImportError):
+        skypy_config(filename)


### PR DESCRIPTION
## Description
Separate the config file parser from the Pipeline class. This allows configurations to be read and then modified in a script before constructing a pipeline, which will be necessary for the lightcone mode implementation in #254.
 
## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
