### PR TITLE
galaxy angular size uses default cosmology

### DIFF
--- a/examples/mccl_galaxies.yml
+++ b/examples/mccl_galaxies.yml
@@ -36,7 +36,6 @@ tables:
     angular_size: !skypy.galaxy.size.angular_size
       physical_size: $red_galaxies.physical_size
       redshift: $red_galaxies.redshift
-      cosmology: $cosmology
     ellipticity: !skypy.galaxy.ellipticity.beta_ellipticity
       e_ratio: 0.45
       e_sum: 3.5
@@ -65,7 +64,6 @@ tables:
     angular_size: !skypy.galaxy.size.angular_size
       physical_size: $blue_galaxies.physical_size
       redshift: $blue_galaxies.redshift
-      cosmology: $cosmology
     ellipticity: !skypy.galaxy.ellipticity.beta_ellipticity
       e_ratio: 0.45
       e_sum: 3.5

--- a/skypy/galaxy/size.py
+++ b/skypy/galaxy/size.py
@@ -6,6 +6,8 @@ This modules computes the angular size of galaxies from their physical size.
 import numpy as np
 from astropy import units
 
+from skypy.utils import uses_default_cosmology
+
 
 __all__ = [
     'angular_size',
@@ -15,6 +17,7 @@ __all__ = [
 ]
 
 
+@uses_default_cosmology
 def angular_size(physical_size, redshift, cosmology):
     """Angular size of a galaxy.
     This function transforms physical radius into angular distance, described
@@ -38,10 +41,7 @@ def angular_size(physical_size, redshift, cosmology):
     Examples
     --------
     >>> from astropy import units
-    >>> from astropy.cosmology import FlatLambdaCDM
-    >>> cosmology = FlatLambdaCDM(H0=67.04, Om0=0.3183, Ob0=0.047745)
-    >>> size = 10.0 * units.kpc
-    >>> angular_size(size, 1, cosmology)
+    >>> angular_size(10*units.kpc, 1)
     <Quantity 5.85990062e-06 rad>
 
     References

--- a/skypy/galaxy/size.py
+++ b/skypy/galaxy/size.py
@@ -42,7 +42,8 @@ def angular_size(physical_size, redshift, cosmology):
     --------
     >>> from astropy import units
     >>> from skypy.galaxy.size import angular_size
-    >>> r = angular_size(10*units.kpc, 1)
+    >>> from astropy.cosmology import Planck15
+    >>> r = angular_size(10*units.kpc, 1, Planck15)
 
     References
     ----------

--- a/skypy/galaxy/size.py
+++ b/skypy/galaxy/size.py
@@ -41,8 +41,8 @@ def angular_size(physical_size, redshift, cosmology):
     Examples
     --------
     >>> from astropy import units
-    >>> angular_size(10*units.kpc, 1)
-    <Quantity 5.85990062e-06 rad>
+    >>> from skypy.galaxy.size import angular_size
+    >>> r = angular_size(10*units.kpc, 1)
 
     References
     ----------


### PR DESCRIPTION
## Description

Quick fix to add the `@uses_default_cosmology` decorator to `skypy.galaxy.size.angular_size` and update the galaxies example, now that the cosmology-setting is working.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
