### PR TITLE
simple construction of quantities in config files

### DIFF
--- a/skypy/pipeline/_config.py
+++ b/skypy/pipeline/_config.py
@@ -1,6 +1,8 @@
 import builtins
 from importlib import import_module
 import yaml
+import re
+from astropy.units import Quantity
 
 __all__ = [
     'load_skypy_yaml',
@@ -52,9 +54,19 @@ class SkyPyLoader(yaml.SafeLoader):
 
         return (function,) if args == '' else (function, args)
 
+    def construct_quantity(self, node):
+        value = self.construct_scalar(node)
+        return Quantity(value)
+
 
 # constructor for generic functions
 SkyPyLoader.add_multi_constructor('!', SkyPyLoader.construct_function)
+
+# constructor for quantities
+SkyPyLoader.add_constructor('!quantity', SkyPyLoader.construct_quantity)
+SkyPyLoader.add_implicit_resolver('!quantity', re.compile(r'''
+    -? [1-9] ( \. [0-9]* [1-9] )? ( e [-+] [1-9] [0-9]* )? \w* \W+
+''', re.VERBOSE), list('-+0123456789.'))
 
 
 def load_skypy_yaml(filename):

--- a/skypy/pipeline/_config.py
+++ b/skypy/pipeline/_config.py
@@ -64,8 +64,10 @@ SkyPyLoader.add_multi_constructor('!', SkyPyLoader.construct_function)
 
 # constructor for quantities
 SkyPyLoader.add_constructor('!quantity', SkyPyLoader.construct_quantity)
+# Implicitly resolve quantities using the regex from astropy
 SkyPyLoader.add_implicit_resolver('!quantity', re.compile(r'''
-    -? [1-9] ( \. [0-9]* [1-9] )? ( e [-+] [1-9] [0-9]* )? \w* \W+
+    \s*[+-]?((\d+\.?\d*)|(\.\d+)|([nN][aA][nN])|
+    ([iI][nN][fF]([iI][nN][iI][tT][yY]){0,1}))([eE][+-]?\d+)?[.+-]? \w* \W+
 ''', re.VERBOSE), list('-+0123456789.'))
 
 

--- a/skypy/pipeline/tests/data/quantities.yml
+++ b/skypy/pipeline/tests/data/quantities.yml
@@ -1,0 +1,2 @@
+42_km: !quantity 42.0 km
+1_deg2: 1 deg2

--- a/skypy/pipeline/tests/test_config.py
+++ b/skypy/pipeline/tests/test_config.py
@@ -2,6 +2,7 @@ from astropy.utils.data import get_pkg_data_filename
 from collections.abc import Callable
 import pytest
 from skypy.pipeline import load_skypy_yaml
+from astropy import units
 
 
 def test_load_skypy_yaml():
@@ -31,3 +32,12 @@ def test_load_skypy_yaml():
     filename = get_pkg_data_filename('data/bad_module.yml')
     with pytest.raises(ImportError):
         load_skypy_yaml(filename)
+
+
+def test_yaml_quantities():
+    # config with quantities
+    filename = get_pkg_data_filename('data/quantities.yml')
+    config = load_skypy_yaml(filename)
+
+    assert config['42_km'] == units.Quantity('42 km')
+    assert config['1_deg2'] == units.Quantity('1 deg2')


### PR DESCRIPTION
## Description

Construct quantities in config files either using the explicit `!quantity` tag or via auto-matching of entries of the form `<number> <string>`. Closes #315.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request