### PR TITLE
fix skypy script documentation

### DIFF
--- a/docs/pipeline/index.rst
+++ b/docs/pipeline/index.rst
@@ -8,8 +8,7 @@ Running SkyPy
 
 The `~skypy.pipeline` package contains the functionality to run a SkyPy
 simulation from end to end. This is implemented in the `~skypy.pipeline.Pipeline`
-class and can be called using the command line script
-`~skypy.pipeline.scripts.skypy`.
+class and can be called using the :ref:`skypy command line script <skypy-script>`.
 
 
 Using a pipeline from other code
@@ -62,8 +61,47 @@ changed for individual executions of the pipeline:
     plt.legend()
 
 
+.. _skypy-script:
+
+Running ``skypy`` from the command line
+=======================================
+
+``skypy`` is a command line script that runs a pipeline of functions defined in
+a config file to generate tables of objects and write them to file.
+
+Using ``skypy`` to run one of the example pipelines and write the outputs to
+fits files:
+
+.. code-block:: bash
+
+    $ skypy examples/mccl_galaxies.yml --format fits
+
+
+Config Files
+------------
+
+Config files are written in yaml format. The top level should contain the
+fields ``cosmology`` and/or ``tables``. ``cosmology`` should contain a
+dictionary configuring a function that returns an
+``astropy.cosmology.Cosmology`` object. ``tables`` should contain a set of
+nested dictionaries, first giving the names of each table, then the names of
+each column within each table. Each column should contain a dictionary
+configuring a function that returns an array-like object.
+
+Each step in the pipeline is configured by a dictionary specifying:
+
+- 'function' : the name of the function
+- 'module' : the name of the the module to import 'function' from
+- 'args' : a list of positional arguments (by value)
+- 'kwargs' : a dictionary of keyword arguments
+- 'requires' : a dictionary of keyword arguments
+
+Note that 'kwargs' specifices keyword arguments by value, wheras 'requires'
+specifices the names of previous steps in the pipeline and uses their return
+values as keyword arguments.
+
+
 Reference/API
 =============
 
 .. automodapi:: skypy.pipeline
-.. automodapi:: skypy.pipeline.scripts.skypy

--- a/skypy/pipeline/scripts/skypy.py
+++ b/skypy/pipeline/scripts/skypy.py
@@ -1,38 +1,4 @@
-"""
-``skypy`` Command Line Script
-=============================
-
-``skypy`` is a command line script that runs a pipeline of functions defined in
-a config file to generate tables of objects and write them to file.
-
-Using ``skypy`` to run one of the example pipelines and write the outputs to
-fits files:
-
-    $ skypy examples/mccl_galaxies.yml --format fits
-
-Config Files
-------------
-
-Config files are written in yaml format. The top level should contain the
-fields ``cosmology`` and/or ``tables``. ``cosmology`` should contain a
-dictionary configuring a function that returns an
-``astropy.cosmology.Cosmology`` object. ``tables`` should contain a set of
-nested dictionaries, first giving the names of each table, then the names of
-each column within each table. Each column should contain a dictionary
-configuring a function that returns an array-like object.
-
-Each step in the pipeline is configured by a dictionary specifying:
-
-- 'function' : the name of the function
-- 'module' : the name of the the module to import 'function' from
-- 'args' : a list of positional arguments (by value)
-- 'kwargs' : a dictionary of keyword arguments
-- 'requires' : a dictionary of keyword arguments
-
-Note that 'kwargs' specifices keyword arguments by value, wheras 'requires'
-specifices the names of previous steps in the pipeline and uses their return
-values as keyword arguments.
-"""
+'''skypy Command Line Script'''
 
 import argparse
 from skypy import __version__ as skypy_version


### PR DESCRIPTION
## Description

Fixes the sphinx error when building the documentation. The cause is that `automodapi` is invoked on the script file, which currently places documentation of all imported symbols there. Fix is to move the script description to the documentation.

I did not fix the outdated documentation itself.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request