### PR TITLE
Make skypy-data an optional dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ install_requires =
     numpy
     scipy
     pyyaml
-    skypy-data @ https://github.com/skypyproject/skypy-data/archive/master.tar.gz
 
 [options.entry_points]
 console_scripts =
@@ -32,10 +31,12 @@ console_scripts =
 test =
     pytest-astropy
     pytest-rerunfailures
+    skypy-data @ https://github.com/skypyproject/skypy-data/archive/master.tar.gz
     specutils
 all =
     camb
     classy @ git+https://github.com/skypyproject/classy.git@v2.8.1#egg=classy
+    skypy-data @ https://github.com/skypyproject/skypy-data/archive/master.tar.gz
     specutils
 docs =
     sphinx-astropy

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,7 @@ exclude_lines =
     pragma: no cover
     # Don't complain about packages we have installed
     except ImportError
+    except ModuleNotFoundError
     # Don't complain if tests don't hit assertions
     raise AssertionError
     raise NotImplementedError

--- a/skypy/galaxy/_spectrum_loaders.py
+++ b/skypy/galaxy/_spectrum_loaders.py
@@ -64,11 +64,11 @@ def skypy_data_loader(module, name, *tags):
         # get resource filename from module, name, and tag
         try:
             filename = resource_filename(f'skypy-data.{module}', f'{name}_{tag}.ecsv')
-        except ModuleNotFoundError:
+        except ModuleNotFoundError as exc:
             message = str("No module named 'skypy-data'. To install:\n"
                           "pip install skypy-data@https://github.com/"
                           "skypyproject/skypy-data/archive/master.tar.gz")
-            raise ModuleNotFoundError(message)
+            raise ModuleNotFoundError(message) from exc
 
         # load the data file
         data = astropy.table.Table.read(filename, format='ascii.ecsv')

--- a/skypy/galaxy/_spectrum_loaders.py
+++ b/skypy/galaxy/_spectrum_loaders.py
@@ -62,7 +62,13 @@ def skypy_data_loader(module, name, *tags):
     for tag in tags:
 
         # get resource filename from module, name, and tag
-        filename = resource_filename(f'skypy-data.{module}', f'{name}_{tag}.ecsv')
+        try:
+            filename = resource_filename(f'skypy-data.{module}', f'{name}_{tag}.ecsv')
+        except ModuleNotFoundError:
+            message = str("No module named 'skypy-data'.  To install:\n"
+                          "pip install skypy-data@https://github.com/"
+                          "skypyproject/skypy-data/archive/master.tar.gz")
+            raise ModuleNotFoundError(message)  # pragma: no cover
 
         # load the data file
         data = astropy.table.Table.read(filename, format='ascii.ecsv')

--- a/skypy/galaxy/_spectrum_loaders.py
+++ b/skypy/galaxy/_spectrum_loaders.py
@@ -68,7 +68,7 @@ def skypy_data_loader(module, name, *tags):
             message = str("No module named 'skypy-data'.  To install:\n"
                           "pip install skypy-data@https://github.com/"
                           "skypyproject/skypy-data/archive/master.tar.gz")
-            raise ModuleNotFoundError(message)  # pragma: no cover
+            raise ModuleNotFoundError(message)
 
         # load the data file
         data = astropy.table.Table.read(filename, format='ascii.ecsv')

--- a/skypy/galaxy/_spectrum_loaders.py
+++ b/skypy/galaxy/_spectrum_loaders.py
@@ -65,7 +65,7 @@ def skypy_data_loader(module, name, *tags):
         try:
             filename = resource_filename(f'skypy-data.{module}', f'{name}_{tag}.ecsv')
         except ModuleNotFoundError:
-            message = str("No module named 'skypy-data'.  To install:\n"
+            message = str("No module named 'skypy-data'. To install:\n"
                           "pip install skypy-data@https://github.com/"
                           "skypyproject/skypy-data/archive/master.tar.gz")
             raise ModuleNotFoundError(message)


### PR DESCRIPTION
## Description
Make skypy-data an optional dependency. Provide installation instructions as part of the ModuleNotFoundError exception message where it is required but not installed. Resolves #321.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
