### PR TITLE
Warning test_template_spectra calculating distance modulus

### DIFF
--- a/skypy/galaxy/tests/test_spectrum.py
+++ b/skypy/galaxy/tests/test_spectrum.py
@@ -173,10 +173,15 @@ def test_template_spectra():
     np.testing.assert_allclose(mt, m)
 
     # Test distance modulus
-    redshift = np.array([0, 1, 2])
+    redshift = np.array([0.00001, 1, 2])
     dm = Planck15.distmod(redshift).value
     mt = magnitudes_from_templates(coefficients, spec, bp, distance_modulus=dm)
     np.testing.assert_allclose(mt, m + dm)
+
+    # Test warning occurs if distance modulus is calculated at redshift 0
+    redshift = 0
+    with pytest.warns(RuntimeWarning):
+        Planck15.distmod(redshift).value
 
     # Test stellar mass
     sm = np.array([1, 2, 3])

--- a/skypy/galaxy/tests/test_spectrum.py
+++ b/skypy/galaxy/tests/test_spectrum.py
@@ -173,15 +173,10 @@ def test_template_spectra():
     np.testing.assert_allclose(mt, m)
 
     # Test distance modulus
-    redshift = np.array([0.00001, 1, 2])
+    redshift = np.array([1, 2, 3])
     dm = Planck15.distmod(redshift).value
     mt = magnitudes_from_templates(coefficients, spec, bp, distance_modulus=dm)
     np.testing.assert_allclose(mt, m + dm)
-
-    # Test warning occurs if distance modulus is calculated at redshift 0
-    redshift = 0
-    with pytest.warns(RuntimeWarning):
-        Planck15.distmod(redshift).value
 
     # Test stellar mass
     sm = np.array([1, 2, 3])


### PR DESCRIPTION
This PR solves #324. A warning was raised when the distance modulus was calculated at redshift 0. These redshifts are excluded now and I added an extra test that a `RuntimeWarning` is raised in this case.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [ ] Assign someone from the infrastructure team to review this pull request
