### PR TITLE
sample positions uniformly over HEALPix pixel

### DIFF
--- a/docs/position/examples/uniform_in_pixel.yml
+++ b/docs/position/examples/uniform_in_pixel.yml
@@ -1,0 +1,8 @@
+# healpix map information
+nside: 2
+
+# sample 500 galaxies in healpix pixel 1
+positions: !skypy.position.uniform_in_pixel
+  nside: $nside
+  ipix: 5
+  size: 500

--- a/docs/position/examples/uniform_in_pixel.yml
+++ b/docs/position/examples/uniform_in_pixel.yml
@@ -1,7 +1,7 @@
 # healpix map information
 nside: 2
 
-# sample 500 galaxies in healpix pixel 1
+# sample 500 galaxies in healpix pixel 5
 positions: !skypy.position.uniform_in_pixel
   nside: $nside
   ipix: 5

--- a/docs/position/index.rst
+++ b/docs/position/index.rst
@@ -33,6 +33,32 @@ use the `~skypy.position.uniform_around` function:
     plt.grid()
 
 
+.. _skypy.position.uniform_in_pixel:
+
+A more complicated uniform distribution is that over a given healpix pixel,
+which is sampled by the `~skypy.position.uniform_in_pixel` function:
+
+.. literalinclude:: examples/uniform_in_pixel.yml
+   :language: yaml
+
+.. plot::
+   :include-source: false
+
+    from skypy.pipeline import Pipeline
+
+    pipeline = Pipeline.read('examples/uniform_in_pixel.yml')
+    pipeline.execute()
+
+    coords = pipeline['positions']
+    ra, dec = coords.ra.wrap_at('180d').radian, coords.dec.radian
+
+    import matplotlib.pyplot as plt
+    plt.figure(figsize=(8,4.2))
+    plt.subplot(111, projection="aitoff")
+    plt.plot(ra, dec, '.', alpha=0.2)
+    plt.grid()
+
+
 Reference/API
 =============
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,10 +36,12 @@ test =
 all =
     camb
     classy @ git+https://github.com/skypyproject/classy.git@v2.8.1#egg=classy
+    healpy
     skypy-data @ https://github.com/skypyproject/skypy-data/archive/master.tar.gz
     specutils
 docs =
     sphinx-astropy
+    healpy
     matplotlib
 
 [options.package_data]

--- a/skypy/position/__init__.py
+++ b/skypy/position/__init__.py
@@ -2,8 +2,9 @@
 
 __all__ = []
 
-from ._uniform import uniform_around
+from ._uniform import uniform_around, uniform_in_pixel
 
 __all__ += [
     'uniform_around',
+    'uniform_in_pixel',
 ]

--- a/skypy/position/_uniform.py
+++ b/skypy/position/_uniform.py
@@ -48,7 +48,7 @@ def uniform_around(centre, area, size):
 
 
 def uniform_in_pixel(nside, ipix, size, nest=False):
-    from healpy.pixelfunc import max_pixrad, pix2ang, ang2pix
+    from healpy import max_pixrad, pix2ang, ang2pix
 
     # get the centre of the healpix pixel as a SkyCoord
     centre_lon, centre_lat = pix2ang(nside, ipix, nest=False, lonlat=True)

--- a/skypy/position/_uniform.py
+++ b/skypy/position/_uniform.py
@@ -51,7 +51,7 @@ def uniform_in_pixel(nside, ipix, size, nest=False):
     '''Uniform distribution of points over healpix pixel.
 
     Draws randomly distributed points from the healpix pixel `ipix` for a map
-    of with `nside` parameter.
+    with a given `nside` parameter.
 
     Parameters
     ----------
@@ -62,8 +62,8 @@ def uniform_in_pixel(nside, ipix, size, nest=False):
     size : int
         Number of points to draw.
     nest : bool, optional
-        Assume ``NESTED`` pixel ordering, or ``RING`` pixel ordering otherwise.
-        Default is ``RING`` pixel ordering.
+        If True assume ``NESTED`` pixel ordering, otherwise ``RING`` pixel
+        ordering. Default is ``RING`` pixel ordering.
 
     Returns
     -------

--- a/skypy/position/_uniform.py
+++ b/skypy/position/_uniform.py
@@ -62,8 +62,8 @@ def uniform_in_pixel(nside, ipix, size, nest=False):
     size : int
         Number of points to draw.
     nest : bool, optional
-        If `True`, assume `NESTED` pixel ordering, or `RING` pixel ordering
-        otherwise. Default is `RING` pixel ordering.
+        Assume ``NESTED`` pixel ordering, or ``RING`` pixel ordering otherwise.
+        Default is ``RING`` pixel ordering.
 
     Returns
     -------
@@ -72,7 +72,7 @@ def uniform_in_pixel(nside, ipix, size, nest=False):
 
     Warnings
     --------
-    This function requires the `healpy` package.
+    This function requires the ``healpy`` package.
 
     Examples
     --------

--- a/skypy/position/_uniform.py
+++ b/skypy/position/_uniform.py
@@ -48,6 +48,38 @@ def uniform_around(centre, area, size):
 
 
 def uniform_in_pixel(nside, ipix, size, nest=False):
+    '''Uniform distribution of points over healpix pixel.
+
+    Draws randomly distributed points from the healpix pixel `ipix` for a map
+    of with `nside` parameter.
+
+    Parameters
+    ----------
+    nside : int
+        Healpix map `nside` parameter.
+    ipix : int
+        Healpix map pixel index.
+    size : int
+        Number of points to draw.
+    nest : bool, optional
+        If `True`, assume `NESTED` pixel ordering, or `RING` pixel ordering
+        otherwise. Default is `RING` pixel ordering.
+
+    Returns
+    -------
+    coords : `~astropy.coordinates.SkyCoord`
+        Randomly distributed points over the healpix pixel.
+
+    Warnings
+    --------
+    This function requires the `healpy` package.
+
+    Examples
+    --------
+    See :ref:`User Documentation <skypy.position.uniform_in_pixel>`.
+
+    '''
+
     from healpy import pix2ang, max_pixrad, nside2pixarea, ang2pix
 
     # get the centre of the healpix pixel as a SkyCoord

--- a/skypy/position/_uniform.py
+++ b/skypy/position/_uniform.py
@@ -102,7 +102,7 @@ def uniform_in_pixel(nside, ipix, size, nest=False):
     miss = size
     while miss > 0:
         # get the coordinates in a circular aperture around centre
-        sample = uniform_around(centre, area, int(miss*over))
+        sample = uniform_around(centre, area, int(np.ceil(miss*over)))
 
         # get longitude and latitude of the sample
         sample_lon, sample_lat = sample.ra.deg, sample.dec.deg

--- a/skypy/position/tests/test_healpy.py
+++ b/skypy/position/tests/test_healpy.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+
+healpy = pytest.importorskip('healpy')
+
+
+def test_uniform_in_pixel_correctness():
+    from skypy.position import uniform_in_pixel
+
+    # 768 healpix pixels
+    nside = 8
+    npix = healpy.nside2npix(nside)
+
+    ipix = np.random.randint(npix)
+
+    pos = uniform_in_pixel(nside, ipix, size=1000)
+    assert len(pos) == 1000
+
+    lon, lat = pos.ra.deg, pos.dec.deg
+    apix = healpy.ang2pix(nside, lon, lat, lonlat=True)
+    np.testing.assert_array_equal(apix, ipix)
+
+
+@pytest.mark.flaky
+def test_uniform_in_pixel_distribution():
+    from scipy.stats import kstest
+
+    from skypy.position import uniform_in_pixel
+
+    # 48 healpix pixels
+    nside = 2
+    npix = healpy.nside2npix(nside)
+
+    # sample entire sky with 20 positions per pixel
+    theta, phi = np.empty(npix*20), np.empty(npix*20)
+    for ipix in range(npix):
+        pos = uniform_in_pixel(nside, ipix, size=20)
+        assert len(pos) == 20
+        theta[ipix*20:(ipix+1)*20] = np.pi/2 - pos.dec.rad
+        phi[ipix*20:(ipix+1)*20] = pos.ra.rad
+
+    # test for uniform distribution
+    D, p = kstest(theta, lambda t: (1 - np.cos(t))/2)
+    assert p > 0.01, 'D = {}, p = {}'.format(D, p)
+    D, p = kstest(phi, 'uniform', args=(0, 2*np.pi))
+    assert p > 0.01, 'D = {}, p = {}'.format(D, p)

--- a/skypy/position/tests/test_healpy.py
+++ b/skypy/position/tests/test_healpy.py
@@ -13,8 +13,9 @@ def test_uniform_in_pixel_correctness():
 
     ipix = np.random.randint(npix)
 
-    pos = uniform_in_pixel(nside, ipix, size=1000)
-    assert len(pos) == 1000
+    size = 1000
+    pos = uniform_in_pixel(nside, ipix, size=size)
+    assert len(pos) == size
 
     lon, lat = pos.ra.deg, pos.dec.deg
     apix = healpy.ang2pix(nside, lon, lat, lonlat=True)
@@ -32,12 +33,13 @@ def test_uniform_in_pixel_distribution():
     npix = healpy.nside2npix(nside)
 
     # sample entire sky with 20 positions per pixel
-    theta, phi = np.empty(npix*20), np.empty(npix*20)
+    size = 20
+    theta, phi = np.empty(npix*size), np.empty(npix*size)
     for ipix in range(npix):
-        pos = uniform_in_pixel(nside, ipix, size=20)
-        assert len(pos) == 20
-        theta[ipix*20:(ipix+1)*20] = np.pi/2 - pos.dec.rad
-        phi[ipix*20:(ipix+1)*20] = pos.ra.rad
+        pos = uniform_in_pixel(nside, ipix, size=size)
+        assert len(pos) == size
+        theta[ipix*size:(ipix+1)*size] = np.pi/2 - pos.dec.rad
+        phi[ipix*size:(ipix+1)*size] = pos.ra.rad
 
     # test for uniform distribution
     D, p = kstest(theta, lambda t: (1 - np.cos(t))/2)


### PR DESCRIPTION
## Description

Adds the `uniform_in_pixel` function to uniformly sample positions over an individual HEALPix pixel.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request