### PR TITLE
Update Readme badges and instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 SkyPy: A package for modelling the Universe
 ===========================================
 
-|Zenodo Badge| |Test Status| |Coverage Status| |PyPI Status| |Anaconda Status| |Documentation Status|
+|Zenodo| |PyPI| |conda-forge| |Read the Docs| |GitHub| |Codecov|
 
 This package contains methods for modelling the Universe, galaxies and the Milky
 Way. Also included are methods for generating observed data.
@@ -114,26 +114,21 @@ Note: This disclaimer was originally written by
 SkyPy based on its use in the README file for the
 `MetPy project <https://github.com/Unidata/MetPy>`_.
 
-.. |Zenodo Badge| image:: https://zenodo.org/badge/221432358.svg
+.. |Zenodo| image:: https://zenodo.org/badge/221432358.svg
    :target: https://zenodo.org/badge/latestdoi/221432358
-   :alt: DOI of Latest SkyPy Release
+   :alt: SkyPy Concept DOI
 
-.. |Test Status| image:: https://github.com/skypyproject/skypy/workflows/Tests/badge.svg
+.. |GitHub| image:: https://github.com/skypyproject/skypy/workflows/Tests/badge.svg
     :target: https://github.com/skypyproject/skypy/actions
-    :alt: SkyPy's Test Status
 
-.. |Coverage Status| image:: https://codecov.io/gh/skypyproject/skypy/branch/master/graph/badge.svg
+.. |Codecov| image:: https://codecov.io/gh/skypyproject/skypy/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/skypyproject/skypy
-    :alt: SkyPy's Coverage Status
 
-.. |PyPI Status| image:: https://img.shields.io/pypi/v/skypy?label=PyPI&logo=pypi
+.. |PyPI| image:: https://img.shields.io/pypi/v/skypy?label=PyPI&logo=pypi
     :target: https://pypi.python.org/pypi/skypy
-    :alt: SkyPy's PyPI Status
 
-.. |Anaconda Status| image:: https://img.shields.io/conda/vn/conda-forge/skypy?logo=conda-forge
+.. |conda-forge| image:: https://img.shields.io/conda/vn/conda-forge/skypy?logo=conda-forge
     :target: https://anaconda.org/conda-forge/skypy
-    :alt: SkyPy's Anaconda Status
 
-.. |Documentation Status| image:: https://img.shields.io/readthedocs/skypy/stable?label=Docs&logo=read%20the%20docs
-    :target: https://skypy.readthedocs.io/en/latest/?badge=latest
-    :alt: Documentation Status
+.. |Read the Docs| image:: https://img.shields.io/readthedocs/skypy/stable?label=Docs&logo=read%20the%20docs
+    :target: https://skypy.readthedocs.io/en/stable

--- a/README.rst
+++ b/README.rst
@@ -54,8 +54,8 @@ One of these is `skypy-data`_ which contains data such as photometric bandpasses
 required for some calculations in SkyPy. This can be installed with:
 
 .. code:: bash
-    
-    pip install skypy-data@https://github.com/skypyproject/skypy-data/archive/master.tar.gz
+
+    $ pip install skypy-data@https://github.com/skypyproject/skypy-data/archive/master.tar.gz
 
 SkyPy also has a driver script that can run simulation pipelines from the
 command line. The `skypyproject/examples`_ repository contains sample
@@ -63,8 +63,8 @@ configuration files that you can clone and run:
 
 .. code:: bash
 
-    git clone --depth 1 -b v$(skypy --version) https://github.com/skypyproject/examples.git
-    skypy examples/mccl_galaxies.yml --format fits
+    $ git clone --depth 1 -b v$(skypy --version) https://github.com/skypyproject/examples.git
+    $ skypy examples/mccl_galaxies.yml --format fits
 
 .. _PyPI: https://pypi.org/project/skypy/
 .. _conda-forge: https://anaconda.org/conda-forge/skypy

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,6 @@ The SkyPy library can then be imported from python:
 .. code:: python
 
     >>> import skypy
-    >>> help(skypy)
 
 SkyPy has a number of optional dependencies which can be installed separately.
 One of these is `skypy-data`_ which contains data such as photometric bandpasses

--- a/README.rst
+++ b/README.rst
@@ -137,14 +137,14 @@ SkyPy based on its use in the README file for the
     :target: https://codecov.io/gh/skypyproject/skypy
     :alt: SkyPy's Coverage Status
 
-.. |PyPI Status| image:: https://img.shields.io/pypi/v/skypy.svg
+.. |PyPI Status| image:: https://img.shields.io/pypi/v/skypy?label=PyPI&logo=pypi
     :target: https://pypi.python.org/pypi/skypy
     :alt: SkyPy's PyPI Status
 
-.. |Anaconda Status| image:: https://anaconda.org/conda-forge/skypy/badges/version.svg
+.. |Anaconda Status| image:: https://img.shields.io/conda/vn/conda-forge/skypy?logo=conda-forge
     :target: https://anaconda.org/conda-forge/skypy
     :alt: SkyPy's Anaconda Status
 
-.. |Documentation Status| image:: https://readthedocs.org/projects/githubapps/badge/?version=latest
+.. |Documentation Status| image:: https://img.shields.io/readthedocs/skypy/stable?label=Docs&logo=read%20the%20docs
     :target: https://skypy.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 SkyPy: A package for modelling the Universe
 ===========================================
 
-|Zenodo Badge| |Astropy Badge| |Test Status| |Coverage Status| |PyPI Status| |Anaconda Status| |Documentation Status|
+|Zenodo Badge| |Test Status| |Coverage Status| |PyPI Status| |Anaconda Status| |Documentation Status|
 
 This package contains methods for modelling the Universe, galaxies and the Milky
 Way. Also included are methods for generating observed data.
@@ -117,10 +117,6 @@ SkyPy based on its use in the README file for the
 .. |Zenodo Badge| image:: https://zenodo.org/badge/221432358.svg
    :target: https://zenodo.org/badge/latestdoi/221432358
    :alt: DOI of Latest SkyPy Release
-
-.. |Astropy Badge| image:: http://img.shields.io/badge/powered%20by-AstroPy-orange.svg?style=flat
-    :target: http://www.astropy.org
-    :alt: Powered by Astropy Badge
 
 .. |Test Status| image:: https://github.com/skypyproject/skypy/workflows/Tests/badge.svg
     :target: https://github.com/skypyproject/skypy/actions

--- a/README.rst
+++ b/README.rst
@@ -43,12 +43,6 @@ To install using conda_:
 
     $ conda install -c conda-forge skypy
 
-You can test your SkyPy intallation using pytest_:
-
-.. code:: bash
-
-    $ pytest --pyargs skypy
-
 The SkyPy library can then be imported from python:
 
 .. code:: python

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 SkyPy: A package for modelling the Universe
 ===========================================
 
-|Zenodo| |PyPI| |conda-forge| |Read the Docs| |GitHub| |Codecov|
+|PyPI| |conda-forge| |Read the Docs| |GitHub| |Codecov| |Zenodo|
 
 This package contains methods for modelling the Universe, galaxies and the Milky
 Way. Also included are methods for generating observed data.
@@ -114,16 +114,6 @@ Note: This disclaimer was originally written by
 SkyPy based on its use in the README file for the
 `MetPy project <https://github.com/Unidata/MetPy>`_.
 
-.. |Zenodo| image:: https://zenodo.org/badge/221432358.svg
-   :target: https://zenodo.org/badge/latestdoi/221432358
-   :alt: SkyPy Concept DOI
-
-.. |GitHub| image:: https://github.com/skypyproject/skypy/workflows/Tests/badge.svg
-    :target: https://github.com/skypyproject/skypy/actions
-
-.. |Codecov| image:: https://codecov.io/gh/skypyproject/skypy/branch/master/graph/badge.svg
-    :target: https://codecov.io/gh/skypyproject/skypy
-
 .. |PyPI| image:: https://img.shields.io/pypi/v/skypy?label=PyPI&logo=pypi
     :target: https://pypi.python.org/pypi/skypy
 
@@ -132,3 +122,13 @@ SkyPy based on its use in the README file for the
 
 .. |Read the Docs| image:: https://img.shields.io/readthedocs/skypy/stable?label=Docs&logo=read%20the%20docs
     :target: https://skypy.readthedocs.io/en/stable
+
+.. |GitHub| image:: https://github.com/skypyproject/skypy/workflows/Tests/badge.svg
+    :target: https://github.com/skypyproject/skypy/actions
+
+.. |Codecov| image:: https://codecov.io/gh/skypyproject/skypy/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/skypyproject/skypy
+
+.. |Zenodo| image:: https://zenodo.org/badge/221432358.svg
+    :target: https://zenodo.org/badge/latestdoi/221432358
+    :alt: SkyPy Concept DOI

--- a/README.rst
+++ b/README.rst
@@ -88,32 +88,6 @@ in the `Code of Conduct`_.
 .. _Contributor Guidelines: CONTRIBUTING.md
 .. _Code of Conduct: CODE_OF_CONDUCT.md
 
-**Imposter syndrome disclaimer**: We want your help. No, really.
-
-There may be a little voice inside your head that is telling you that you're not
-ready to be an open source contributor; that your skills aren't nearly good
-enough to contribute. What could you possibly offer a project like this one?
-
-We assure you - the little voice in your head is wrong. If you can write code at
-all, you can contribute code to open source. Contributing to open source
-projects is a fantastic way to advance one's coding skills. Writing perfect code
-isn't the measure of a good developer (that would disqualify all of us!); it's
-trying to create something, making mistakes, and learning from those
-mistakes. That's how we all improve, and we are happy to help others learn.
-
-Being an open source contributor doesn't just mean writing code, either. You can
-help out by writing documentation, tests, or even giving feedback about the
-project (and yes - that includes giving feedback about the contribution
-process). Some of these contributions may be the most valuable to the project as
-a whole, because you're coming to the project with fresh eyes, so you can see
-the errors and assumptions that seasoned contributors have glossed over.
-
-Note: This disclaimer was originally written by
-`Adrienne Lowe <https://github.com/adriennefriend>`_ for a
-`PyCon talk <https://www.youtube.com/watch?v=6Uj746j9Heo>`_, and was adapted by
-SkyPy based on its use in the README file for the
-`MetPy project <https://github.com/Unidata/MetPy>`_.
-
 .. |PyPI| image:: https://img.shields.io/pypi/v/skypy?label=PyPI&logo=pypi
     :target: https://pypi.python.org/pypi/skypy
 


### PR DESCRIPTION
## Description
New README can be viewed [here](https://github.com/rrjbca/skypy/blob/readme/README.rst). Changes include:

- New CI badges with logos
- Documentation badge links to 'stable' instead of 'latest'
- Remove instructions for how the user can run tests. The tests are intended for our CI. The existing instructions do not specify installing the testing dependencies and so were incomplete anyway.
- Remove `help(skypy)` from the instructions for importing skypy
- Remove imposter syndrome disclaimer

## Question
- [x] Do we want to remove the Imposter syndrome disclaimer in the README? It was originally added as part of the [astropy package template](https://github.com/astropy/package-template). But astropy themselves keep it in their [contributor guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and other astropy affiliated packages do not include it at all.
## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
