### PR TITLE
Multicolumn assignment call pattern depends on astropy version

### DIFF
--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -4,6 +4,7 @@ This module provides methods to run pipelines of functions with dependencies
 and handle their results.
 """
 
+from astropy import __version__ as astropy_version
 from astropy.cosmology import default_cosmology
 from astropy.table import Table
 from copy import copy, deepcopy
@@ -187,7 +188,11 @@ class Pipeline:
                     if len(names) > 1:
                         # Multi-column assignment
                         t = Table(self.get_value(settings), names=names)
-                        self.state[table].add_columns(t.columns.values())
+                        if astropy_version.startswith('3.'):  # pragma: no cover
+                            self.state[table].add_columns(t.columns.values())
+                        else:
+                            self.state[table].add_columns(t.columns)
+
                     else:
                         # Single column assignment
                         self.state[table][column] = self.get_value(settings)


### PR DESCRIPTION
## Description
On the astropy master branch, `Table.add_columns` now expects columns to be passed as a `TableColumns` object and no longer accepts a list of `Column` objects. This breaks our current implementation of multi-column assignment and causes our `dev` tests in the [`Compatibility Workflow`](https://github.com/skypyproject/skypy/actions/runs/313272229) to fail. This PR checks the astropy version to determine which pattern to use when calling `add_columns`. Tested locally using astropy versions 3.2.3, 4.0.2 and master.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
