### PR TITLE
Flatten python module index in docs

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -121,6 +121,12 @@
             "affiliation": "University of Portsmouth",
             "name": "Andrew R. Williamson",
             "type": "ProjectMember"
+        },
+        {
+            "orcid": "0000-0003-3954-3291",
+            "affiliation": "University of Toronto",
+            "name": "Nathaniel Starkman",
+            "type": "Other"
         }
     ],
     "access_right": "open"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,6 +138,9 @@ html_title = '{0} v{1}'.format(project, release)
 # Output file base name for HTML help builder.
 htmlhelp_basename = project + 'doc'
 
+# Prefixes that are ignored for sorting the Python module index
+modindex_common_prefix = ["skypy."]
+
 
 # -- Options for LaTeX output -------------------------------------------------
 


### PR DESCRIPTION
## Description

Implementing something like astropy/package-template#495 will make the python [module index ](https://skypy.readthedocs.io/en/latest/py-modindex.html) more easily searchable.

Signed-off-by: Nathaniel Starkman <nstarkman@protonmail.com>

Fixes #348 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] ~Write unit tests~
- [x] ~Write documentation strings~
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
