### PR TITLE
Drop support for Astropy 3.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ packages = find:
 python_requires = >=3.6
 setup_requires = setuptools_scm
 install_requires =
-    astropy
+    astropy>=4
     networkx
     numpy
     scipy

--- a/skypy/galaxy/_spectrum_loaders.py
+++ b/skypy/galaxy/_spectrum_loaders.py
@@ -3,7 +3,6 @@
 import numpy as np
 import astropy.utils.data
 import astropy.table
-from astropy import __version__ as astropy_version
 from astropy import units
 
 import os
@@ -20,10 +19,7 @@ except ImportError:
 
 def download_file(url, cache=True):
     '''download_file with some specific settings'''
-    if astropy_version.startswith('3.'):  # pragma: no cover
-        extra_kwargs = {}
-    else:
-        extra_kwargs = {'pkgname': 'skypy'}
+    extra_kwargs = {'pkgname': 'skypy'}
     return astropy.utils.data.download_file(
             url, cache=cache, show_progress=False, **extra_kwargs)
 

--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -187,7 +187,7 @@ class Pipeline:
                     if len(names) > 1:
                         # Multi-column assignment
                         t = Table(self.get_value(settings), names=names)
-                        self.state[table].add_columns(t.columns.values())
+                        self.state[table].add_columns(t.columns)
                     else:
                         # Single column assignment
                         self.state[table][column] = self.get_value(settings)

--- a/tox.ini
+++ b/tox.ini
@@ -68,11 +68,11 @@ deps =
     dev: :NIGHTLY:scipy
     dev: git+https://github.com/astropy/astropy.git#egg=astropy
 
-    latest: astropy==4.0.*
+    latest: astropy==4.1.*
     latest: numpy==1.19.*
     latest: scipy==1.5.*
 
-    oldest: astropy==3.2.*
+    oldest: astropy==4.0.*
     oldest: numpy==1.16.*
     oldest: scipy==1.2.*
 


### PR DESCRIPTION
## Description
Drop support for Astropy 3.x:
- Remove outdated API support for `download_file` and `add_columns`
- Update oldest and latest versions to 4.0.x and 4.1.x respectively

Resolves #350 and supersedes #349 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] ~Write unit tests~
- [ ] ~Write documentation strings~
- [ ] ~Assign someone from your working team to review this pull request~
- [x] Assign someone from the infrastructure team to review this pull request
