### PR TITLE
Pipeline.__getitem__ returns column data as a Quantity or ndarray

### DIFF
--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -292,4 +292,7 @@ class Pipeline:
     def __getitem__(self, label):
         name, _, key = label.partition('.')
         item = self.state[name]
-        return item[key].quantity if key else item
+        if key:
+            return item[key].data if item[key].unit is None else item[key].quantity
+        else:
+            return item

--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -292,4 +292,4 @@ class Pipeline:
     def __getitem__(self, label):
         name, _, key = label.partition('.')
         item = self.state[name]
-        return item[key] if key else item
+        return item[key].quantity if key else item

--- a/skypy/pipeline/tests/test_pipeline.py
+++ b/skypy/pipeline/tests/test_pipeline.py
@@ -203,12 +203,13 @@ def test_column_quantity():
 
     # Regression test for pull request #356
     # Previously Pipeline.__getitem__ would return column data from tables as
-    # an astropy.table.Column object instead of an astropy.units.Quantity
-    # object. As of astropy version 4.1.0 Column does not support all of the
-    # same class methods as Quantity e.g. to_value. This test ensures that
-    # column data in a Pipeline is accessed as a Quantity and that functions
-    # using methods not supported by Column can be called inside a Pipeline
-    # on column data.
+    # an astropy.table.Column object. However, most functions take either
+    # numpy.ndarray or astropy.units.Quantity objects as arguments. As of
+    # astropy version 4.1.0 Column does not support all of the same class
+    # methods as Quantity e.g. to_value. This test ensures that column data in
+    # a Pipeline is accessed as either an ndarray or Quantity (depending on
+    # units). It also checks that functions using methods not supported by
+    # Column can be called on column data inside a Pipeline.
 
     def value_in_cm(q):
         return q.to_value(unit='cm')
@@ -223,6 +224,7 @@ def test_column_quantity():
     pipeline.execute()
 
     assert isinstance(pipeline['test_table.lengths'], Quantity)
+    assert isinstance(pipeline['test_table.lengths_in_cm'], np.ndarray)
     np.testing.assert_array_less(0, pipeline['test_table.lengths_in_cm'])
     np.testing.assert_array_less(pipeline['test_table.lengths_in_cm'], 100)
 


### PR DESCRIPTION
## Description
`Pipeline.__getitem__` currently retrieves column data as an `astropy.table.Column` object. This is problematic as many of our functions are written to expect `astropy.units.Quantity` objects as arguments but the `Column` class doesn't support all of the same methods of the `Quantity` class e.g. `to_value`. This pull request modifies `Pipeline.__getitem__` to return column data as an `astropy.units.Quantity` object. Resolves #355. 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [ ] ~Write documentation strings~
- [ ] ~Assign someone from your working team to review this pull request~
- [x] Assign someone from the infrastructure team to review this pull request
