### PR TITLE
Explicitly use Planck15 cosmology in tests

### DIFF
--- a/skypy/power_spectrum/_eisenstein_hu.py
+++ b/skypy/power_spectrum/_eisenstein_hu.py
@@ -46,15 +46,14 @@ def transfer_with_wiggles(wavenumber, A_s, n_s, cosmology, kwmap=0.02):
     Examples
     --------
 
-    This returns the transfer function with wiggles for the Astropy default
+    This returns the transfer function with wiggles for the Planck 2015
     cosmology at a given array of wavenumbers:
 
     >>> import numpy as np
-    >>> from astropy.cosmology import default_cosmology
+    >>> from astropy.cosmology import Planck15
     >>> wavenumber = np.logspace(-3, 1, num=5, base=10.0)
     >>> A_s, n_s = 2.1982e-09, 0.969453
-    >>> cosmology = default_cosmology.get()
-    >>> transfer_with_wiggles(wavenumber, A_s, n_s, cosmology, kwmap=0.02)
+    >>> transfer_with_wiggles(wavenumber, A_s, n_s, Planck15, kwmap=0.02)
     array([9.92144790e-01, 7.78548704e-01, 1.29998169e-01, 4.63863054e-03,
        8.87918075e-05])
 
@@ -183,15 +182,14 @@ def transfer_no_wiggles(wavenumber, A_s, n_s, cosmology):
     Examples
     --------
 
-    This returns the transfer function without wiggles for the Astropy default
+    This returns the transfer function without wiggles for the Planck 2015
     cosmology at a given array of wavenumbers:
 
     >>> import numpy as np
-    >>> from astropy.cosmology import default_cosmology
+    >>> from astropy.cosmology import Planck15
     >>> wavenumber = np.logspace(-3, 1, num=5, base=10.0)
     >>> A_s, n_s = 2.1982e-09, 0.969453
-    >>> cosmology = default_cosmology.get()
-    >>> transfer_no_wiggles(wavenumber, A_s, n_s, cosmology)
+    >>> transfer_no_wiggles(wavenumber, A_s, n_s, Planck15)
     array([9.91959695e-01, 7.84518347e-01, 1.32327555e-01, 4.60773671e-03,
        8.78447096e-05])
 
@@ -266,16 +264,14 @@ def eisenstein_hu(wavenumber, A_s, n_s, cosmology, kwmap=0.02, wiggle=True):
     --------
 
     This example returns the Eisenstein and Hu matter power spectrum with
-    baryon acoustic oscillations for the Astropy default
+    baryon acoustic oscillations for the Planck 2015
     cosmology at a given array of wavenumbers:
 
     >>> import numpy as np
-    >>> from astropy.cosmology import default_cosmology
+    >>> from astropy.cosmology import Planck15
     >>> wavenumber = np.logspace(-3, 1, num=5, base=10.0)
     >>> A_s, n_s = 2.1982e-09, 0.969453
-    >>> cosmology = default_cosmology.get()
-    >>> eisenstein_hu(wavenumber, A_s, n_s, cosmology, kwmap=0.02,
-    ...               wiggle=True)
+    >>> eisenstein_hu(wavenumber, A_s, n_s, Planck15, kwmap=0.02, wiggle=True)
     array([6.47460158e+03, 3.71610099e+04, 9.65702614e+03, 1.14604456e+02,
        3.91399918e-01])
 

--- a/skypy/power_spectrum/_growth.py
+++ b/skypy/power_spectrum/_growth.py
@@ -42,13 +42,12 @@ def growth_function_carroll(redshift, cosmology):
     --------
 
     This example returns the growth function for a given array of redshifts
-    and for the Astropy default cosmology:
+    and for the Planck 2015 cosmology:
 
     >>> import numpy as np
-    >>> from astropy.cosmology import default_cosmology
+    >>> from astropy.cosmology import Planck15
     >>> redshift = np.array([0, 1, 2])
-    >>> cosmology = default_cosmology.get()
-    >>> growth_function_carroll(redshift, cosmology)
+    >>> growth_function_carroll(redshift, Planck15)
     array([0.781361..., 0.476280..., 0.327549...])
 
     References

--- a/skypy/power_spectrum/tests/test_eisenstein_hu.py
+++ b/skypy/power_spectrum/tests/test_eisenstein_hu.py
@@ -1,13 +1,13 @@
 import numpy as np
 import pytest
-from astropy.cosmology import default_cosmology, FlatLambdaCDM
+from astropy.cosmology import Planck15, FlatLambdaCDM
 from skypy.power_spectrum import eisenstein_hu
 
 
 def test_eisenstein_hu():
     """ Test Eisenstein & Hu Linear matter power spectrum with
-    and without wiggles using astropy default cosmology"""
-    cosmology = default_cosmology.get()
+    and without wiggles using Planck15 cosmology"""
+    cosmology = Planck15
     A_s = 2.1982e-09
     n_s = 0.969453
     kwmap = 0.02
@@ -31,7 +31,7 @@ def test_eisenstein_hu():
     assert array_output_w.shape == array_shape
     assert array_output_nw.shape == array_shape
 
-    # Test pk against precomputed values for default_cosmology
+    # Test pk against precomputed values for Planck15 cosmology
     wavenumber = np.logspace(-3, 1, num=5, base=10.0)
     pk_eisensteinhu_w = eisenstein_hu(wavenumber, A_s, n_s, cosmology, kwmap,
                                       wiggle=True)

--- a/skypy/power_spectrum/tests/test_growth.py
+++ b/skypy/power_spectrum/tests/test_growth.py
@@ -1,5 +1,5 @@
 import numpy as np
-from astropy.cosmology import FlatLambdaCDM, default_cosmology, Planck15
+from astropy.cosmology import FlatLambdaCDM, Planck15
 from astropy.units import isclose, allclose
 import pytest
 
@@ -46,7 +46,7 @@ def test_carroll():
 def test_growth():
     """
     Test a FlatLambdaCDM cosmology with omega_matter = 1.0
-    and astropy default cosmology
+    and Planck15 cosmology
     """
 
     redshift = np.linspace(0., 10., 101)
@@ -79,21 +79,19 @@ def test_growth():
     assert isclose(Dzprime[0], -1.0),\
         "Derivative of growth function at redshift 0 is not close to -1.0"
 
-    # Test against precomputed values using astropy default cosmology
-    default = default_cosmology.get()
+    # Test against precomputed values using Planck15 cosmology
     zvec = np.linspace(0.0, 1.0, 4)
+    fz_planck15 = growth_factor(zvec, Planck15)
+    Dz_planck15 = growth_function(zvec, Planck15)
+    Dzprime_planck15 = growth_function_derivative(zvec, Planck15)
 
-    fz_default = growth_factor(zvec, default)
-    Dz_default = growth_function(zvec, default)
-    Dzprime_default = growth_function_derivative(zvec, default)
+    precomputed_fz_planck15 = np.array([0.5255848, 0.69412802, 0.80439553,
+                                        0.87179376])
+    precomputed_Dz_planck15 = np.array([0.66328939, 0.55638978, 0.4704842,
+                                        0.40368459])
+    precomputed_Dzprime_planck15 = np.array([-0.34861482, -0.2896543,
+                                             -0.22707323, -0.17596485])
 
-    precomputed_fz_default = np.array([0.5255848, 0.69412802, 0.80439553,
-                                       0.87179376])
-    precomputed_Dz_default = np.array([0.66328939, 0.55638978, 0.4704842,
-                                       0.40368459])
-    precomputed_Dzprime_default = np.array([-0.34861482, -0.2896543,
-                                            -0.22707323, -0.17596485])
-
-    assert allclose(fz_default, precomputed_fz_default)
-    assert allclose(Dz_default, precomputed_Dz_default)
-    assert allclose(Dzprime_default, precomputed_Dzprime_default)
+    assert allclose(fz_planck15, precomputed_fz_planck15)
+    assert allclose(Dz_planck15, precomputed_Dz_planck15)
+    assert allclose(Dzprime_planck15, precomputed_Dzprime_planck15)


### PR DESCRIPTION
## Description
The astropy default cosmology will change from `Planck15` to `Planck18` in v4.2. This pull request updates all tests currently using the cosmology returned by `default_cosmology.get()` to compute and compare values to use `Planck15` explicitly.  Resolves #366 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [ ] ~Assign someone from your working team to review this pull request~
- [x] Assign someone from the infrastructure team to review this pull request
