### PR TITLE
Access filter responses with speclite package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,12 +33,14 @@ test =
     pytest-rerunfailures
     skypy-data @ https://github.com/skypyproject/skypy-data/archive/master.tar.gz
     specutils
+    speclite @ git+https://github.com/desihub/speclite.git
 all =
     camb
     classy @ git+https://github.com/skypyproject/classy.git@v2.8.1#egg=classy
     healpy
     skypy-data @ https://github.com/skypyproject/skypy-data/archive/master.tar.gz
     specutils
+    speclite @ git+https://github.com/desihub/speclite.git
 docs =
     sphinx-astropy
     healpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,14 +33,14 @@ test =
     pytest-rerunfailures
     skypy-data @ https://github.com/skypyproject/skypy-data/archive/master.tar.gz
     specutils
-    speclite @ git+https://github.com/desihub/speclite.git
+    speclite != 0.9
 all =
     camb
     classy @ git+https://github.com/skypyproject/classy.git@v2.8.1#egg=classy
     healpy
     skypy-data @ https://github.com/skypyproject/skypy-data/archive/master.tar.gz
     specutils
-    speclite @ git+https://github.com/desihub/speclite.git
+    speclite != 0.9
 docs =
     sphinx-astropy
     healpy

--- a/skypy/galaxy/_spectrum_loaders.py
+++ b/skypy/galaxy/_spectrum_loaders.py
@@ -24,13 +24,6 @@ except ImportError:
     pass
 
 
-def download_file(url, cache=True):
-    '''download_file with some specific settings'''
-    extra_kwargs = {'pkgname': 'skypy'}
-    return astropy.utils.data.download_file(
-            url, cache=cache, show_progress=False, **extra_kwargs)
-
-
 def combine_spectra(a, b):
     '''combine two spectra'''
     if a is None or b is None:
@@ -117,7 +110,7 @@ def speclite_loader(name, *bands):
         filter_object = speclite.filters.load_filter(filter_name)
 
         # get the spectral axis as astropy quantity
-        spectral_axis = units.Quantity(filter_object._wavelength, units.angstrom)
+        spectral_axis = filter_object.wavelength*speclite.filters.default_wavelength_unit
 
         # get throughput
         throughput = filter_object.response * units.dimensionless_unscaled

--- a/skypy/galaxy/spectrum.py
+++ b/skypy/galaxy/spectrum.py
@@ -22,6 +22,13 @@ else:
     HAS_SPECUTILS = True
 
 try:
+    __import__('speclite')
+except ImportError:
+    HAS_SPECLITE = False
+else:
+    HAS_SPECLITE = True
+
+try:
     __import__('skypy-data')
 except ImportError:
     HAS_SKYPY_DATA = False
@@ -341,6 +348,7 @@ def load_spectral_data(name):
     Warnings
     --------
     The :mod:`specutils` package must be installed to use this function.
+    The :mod:`speclite` package must be installed to use this function.
 
     '''
 

--- a/skypy/galaxy/tests/test_spectrum.py
+++ b/skypy/galaxy/tests/test_spectrum.py
@@ -239,20 +239,13 @@ def test_load_spectral_data():
     filename = get_pkg_data_filename('data/spectrum.ecsv')
     load_spectral_data(filename)
 
-    # load speclite bandpasses
     # load skypy data spectrum templates
     load_spectral_data('kcorrect_spec')
 
-    # load DECam bandpasses
+    # Load speclite bandpasses
     load_spectral_data('decam2014_ugrizY')
-
-    # load SDSS bandpasses
     load_spectral_data('sdss2010_ugriz')
-
-    # load WISE bandpasses
     load_spectral_data('wise2010_W1W2W3W4')
-
-    # load Bessel bandpasses
     load_spectral_data('bessell_UBVRI')
 
     # load multiple sources

--- a/skypy/galaxy/tests/test_spectrum.py
+++ b/skypy/galaxy/tests/test_spectrum.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.stats
 import pytest
-from skypy.galaxy.spectrum import HAS_SPECUTILS, HAS_SKYPY_DATA
+from skypy.galaxy.spectrum import HAS_SPECUTILS, HAS_SKYPY_DATA, HAS_SPECLITE
 
 
 @pytest.mark.flaky
@@ -228,8 +228,8 @@ def test_stellar_mass_from_reference_band():
     np.testing.assert_allclose(stellar_mass, truth)
 
 
-@pytest.mark.skipif(not HAS_SPECUTILS or not HAS_SKYPY_DATA,
-                    reason='test requires specutils and skypy-data')
+@pytest.mark.skipif(not HAS_SPECUTILS or not HAS_SKYPY_DATA or not HAS_SPECLITE,
+                    reason='test requires specutils, skypy-data and speclite')
 def test_load_spectral_data():
 
     from skypy.galaxy.spectrum import load_spectral_data
@@ -239,18 +239,24 @@ def test_load_spectral_data():
     filename = get_pkg_data_filename('data/spectrum.ecsv')
     load_spectral_data(filename)
 
-    # load skypy data bandpasses
-    load_spectral_data('Johnson_UBV')
-    load_spectral_data('Cousins_RI')
-
+    # load speclite bandpasses
     # load skypy data spectrum templates
     load_spectral_data('kcorrect_spec')
 
     # load DECam bandpasses
-    load_spectral_data('DECam_grizY')
+    load_spectral_data('decam2014_ugrizY')
+
+    # load SDSS bandpasses
+    load_spectral_data('sdss2010_ugriz')
+
+    # load WISE bandpasses
+    load_spectral_data('wise2010_W1W2W3W4')
+
+    # load Bessel bandpasses
+    load_spectral_data('bessell_UBVRI')
 
     # load multiple sources
-    load_spectral_data(['Johnson_B', 'Cousins_R'])
+    load_spectral_data(['BASS_gr', 'MzLS_z'])
 
     # try to load non-string name
     with pytest.raises(TypeError):

--- a/skypy/utils/tests/test_decorators.py
+++ b/skypy/utils/tests/test_decorators.py
@@ -94,7 +94,7 @@ def test_spectral_data_input():
     def my_bandpass_function(bandpass):
         pass
 
-    #my_bandpass_function('bessell_B')
+    my_bandpass_function('bessell_B')
 
     with pytest.raises(units.UnitConversionError):
         my_bandpass_function('kcorrect_spec')

--- a/skypy/utils/tests/test_decorators.py
+++ b/skypy/utils/tests/test_decorators.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from skypy.galaxy.spectrum import HAS_SPECUTILS, HAS_SKYPY_DATA
+from skypy.galaxy.spectrum import HAS_SPECUTILS, HAS_SKYPY_DATA, HAS_SPECLITE
 
 
 def test_uses_default_cosmology():
@@ -83,7 +83,7 @@ def test_dependent_argument():
             pass
 
 
-@pytest.mark.skipif(not HAS_SPECUTILS or not HAS_SKYPY_DATA,
+@pytest.mark.skipif(not HAS_SPECUTILS or not HAS_SKYPY_DATA or not HAS_SPECLITE,
                     reason='test requires specutils and skypy-data')
 def test_spectral_data_input():
 
@@ -93,6 +93,8 @@ def test_spectral_data_input():
     @spectral_data_input(bandpass=units.dimensionless_unscaled)
     def my_bandpass_function(bandpass):
         pass
+
+    #my_bandpass_function('bessell_B')
 
     with pytest.raises(units.UnitConversionError):
         my_bandpass_function('kcorrect_spec')

--- a/skypy/utils/tests/test_decorators.py
+++ b/skypy/utils/tests/test_decorators.py
@@ -94,8 +94,6 @@ def test_spectral_data_input():
     def my_bandpass_function(bandpass):
         pass
 
-    my_bandpass_function('Johnson_B')
-
     with pytest.raises(units.UnitConversionError):
         my_bandpass_function('kcorrect_spec')
 


### PR DESCRIPTION
## Description
This PR solves issue #361. 

In order to add the SDSS filters, we found the `speclite` package which includes multiple filter response curves. 
The advantages of this package is that we don’t have to worry about anything related to licenses and keeping the data up-to-date.
Furthermore, it includes a function where you can create your own filter responds objects. This can be also integrated in the future.
## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [ ] Assign someone from the infrastructure team to review this pull request
