### PR TITLE
fail on warnings for RTD sphinx build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,6 +3,9 @@ version: 2
 build:
   image: latest
 
+sphinx:
+  fail_on_warning: true
+
 python:
   version: 3.7
   install:


### PR DESCRIPTION
notify us of documentation warnings by failing the ReadTheDocs build