### PR TITLE
pipeline: functions are (function, args, kwargs)

### DIFF
--- a/skypy/pipeline/_config.py
+++ b/skypy/pipeline/_config.py
@@ -65,7 +65,7 @@ class SkyPyLoader(yaml.SafeLoader):
 
         if isinstance(node, yaml.ScalarNode):
             arg = self.construct_scalar(node)
-            args = [arg] if arg else []
+            args = [arg] if arg != '' else []
             kwargs = {}
         elif isinstance(node, yaml.SequenceNode):
             args = self.construct_sequence(node)

--- a/skypy/pipeline/tests/test_config.py
+++ b/skypy/pipeline/tests/test_config.py
@@ -19,7 +19,7 @@ def test_load_skypy_yaml():
     assert isinstance(config['test_str'], str)
     assert isinstance(config['test_func'], tuple)
     assert isinstance(config['test_cosmology'][0], Callable)
-    assert isinstance(config['test_cosmology'][1], dict)
+    assert isinstance(config['test_cosmology'][2], dict)
     assert isinstance(config['tables']['test_table_1']['test_column_3'][0], Callable)
     assert isinstance(config['tables']['test_table_1']['test_column_3'][1], list)
 

--- a/skypy/pipeline/tests/test_lightcone.py
+++ b/skypy/pipeline/tests/test_lightcone.py
@@ -15,8 +15,8 @@ def test_lightcone():
     config = {'lightcone': {'z_min': z_min, 'z_max': z_max, 'n_slice': n_slice},
               'tables':
               {'test_table':
-               {'z1': (np.random.uniform, ['$slice_z_min', '$slice_z_max', nz]),
-                'z2': (np.random.uniform, ['$slice_z_mid', '$slice_z_max', nz])
+               {'z1': (np.random.uniform, ['$slice_z_min', '$slice_z_max', nz], {}),
+                'z2': (np.random.uniform, ['$slice_z_mid', '$slice_z_max', nz], {})
                 }
                }
               }
@@ -42,7 +42,7 @@ def test_lightcone():
 
     # Repeat test with non-default cosmology
     config['parameters'] = {'H0': 70, 'Om0': 0.3}
-    config['cosmology'] = (FlatLambdaCDM, {'H0': '$H0', 'Om0': '$Om0'})
+    config['cosmology'] = (FlatLambdaCDM, [], {'H0': '$H0', 'Om0': '$Om0'})
     lightcone = Lightcone(config)
     lightcone.execute()
     chi1 = lightcone.cosmology.comoving_distance(lightcone.tables['test_table']['z1'])


### PR DESCRIPTION
Standardise the definition of a function in the pipeline class as a tuple `(function, args, kwargs)` that has three elements: a callable `function`, a list `args`, and a dict `kwargs`. The function call is then always `function(*args, **kwargs)`.