### PR TITLE
pipeline: do not use default_cosmology

### DIFF
--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -26,7 +26,7 @@ def infer(function, args, kwargs, context):
     try:
         # inspect the function
         sig = inspect.signature(function)
-    except:
+    except ValueError:
         # not all functions can be inspected
         sig = None
 

--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -9,11 +9,51 @@ from astropy.table import Table, Column
 from copy import copy, deepcopy
 from ._config import load_skypy_yaml
 import networkx
+import inspect
 
 
 __all__ = [
     'Pipeline',
 ]
+
+
+def infer(function, args, kwargs, context):
+    '''infer missing function args and kwargs from context
+
+    TODO: move this into the PipelineFunction() class once it exists
+    '''
+
+    try:
+        # inspect the function
+        sig = inspect.signature(function)
+    except:
+        # not all functions can be inspected
+        sig = None
+
+    if sig is not None:
+        # inspect the function call for the given args and kwargs
+        given = sig.bind_partial(*args, **kwargs)
+
+        # now go through parameters one by one:
+        # - check if the parameter has an argument given
+        # - if not, check if the parameter has a default argument
+        # - if not, check if the argument can be inferred from context
+        for name, par in sig.parameters.items():
+            if name in given.arguments:
+                pass
+            elif par.default is not par.empty:
+                pass
+            elif name in context:
+                given.arguments[name] = context[name]
+
+        # augment args and kwargs
+        args.clear()
+        args.extend(given.args)
+        kwargs.clear()
+        kwargs.update(given.kwargs)
+
+    # return if successful
+    return True if sig is not None else False
 
 
 class Pipeline:
@@ -75,7 +115,7 @@ class Pipeline:
         # config contains settings for all variables and table initialisation
         # table_config contains settings for all table columns
         self.config = deepcopy(configuration)
-        self.cosmology = self.config.pop('cosmology', {})
+        self.cosmology = self.config.pop('cosmology', None)
         self.parameters = self.config.pop('parameters', {})
         self.table_config = self.config.pop('tables', {})
         default_table = (Table, [], {})
@@ -88,6 +128,13 @@ class Pipeline:
         # Create a Directed Acyclic Graph of all jobs and dependencies
         self.dag = networkx.DiGraph()
 
+        # context for function calls
+        context = {}
+
+        # use cosmology in global context if given
+        if self.cosmology is not None:
+            context['cosmology'] = '$cosmology'
+
         # - add nodes for each variable, table and column
         # - add edges for the table dependencies
         # - keep track where functions need to be called
@@ -97,6 +144,9 @@ class Pipeline:
             self.dag.add_node(job, skip=False)
             if isinstance(settings, tuple):
                 functions[job] = settings
+                # infer additional function arguments from context
+                function, args, kwargs = settings
+                infer(function, args, kwargs, context)
         for table, columns in self.table_config.items():
             table_complete = '.'.join((table, 'complete'))
             self.dag.add_node(table_complete)
@@ -108,6 +158,9 @@ class Pipeline:
                 self.dag.add_edge(job, table_complete)
                 if isinstance(settings, tuple):
                     functions[job] = settings
+                    # infer additional function arguments from context
+                    function, args, kwargs = settings
+                    infer(function, args, kwargs, context)
                 # DAG nodes for individual columns in multi-column assignment
                 names = [n.strip() for n in column.split(',')]
                 if len(names) > 1:
@@ -156,35 +209,30 @@ class Pipeline:
         # initialise state object
         self.state = copy(self.parameters)
 
-        # Initialise cosmology from config parameters or use astropy default
-        if self.cosmology:
+        # Initialise cosmology from config parameters
+        if self.cosmology is not None:
             self.state['cosmology'] = self.get_value(self.cosmology)
-        else:
-            self.state['cosmology'] = default_cosmology.get()
 
-        # Execute pipeline setting state cosmology as the default
-        with default_cosmology.set(self.state['cosmology']):
-
-            # go through the jobs in dependency order
-            for job in networkx.topological_sort(self.dag):
-                node = self.dag.nodes[job]
-                skip = node.get('skip', True)
-                if skip:
-                    continue
-                elif job in self.config:
-                    settings = self.config.get(job)
-                    self.state[job] = self.get_value(settings)
+        # go through the jobs in dependency order
+        for job in networkx.topological_sort(self.dag):
+            node = self.dag.nodes[job]
+            skip = node.get('skip', True)
+            if skip:
+                continue
+            elif job in self.config:
+                settings = self.config.get(job)
+                self.state[job] = self.get_value(settings)
+            else:
+                table, column = job.split('.')
+                settings = self.table_config[table][column]
+                names = [n.strip() for n in column.split(',')]
+                if len(names) > 1:
+                    # Multi-column assignment
+                    t = Table(self.get_value(settings), names=names)
+                    self.state[table].add_columns(t.columns)
                 else:
-                    table, column = job.split('.')
-                    settings = self.table_config[table][column]
-                    names = [n.strip() for n in column.split(',')]
-                    if len(names) > 1:
-                        # Multi-column assignment
-                        t = Table(self.get_value(settings), names=names)
-                        self.state[table].add_columns(t.columns)
-                    else:
-                        # Single column assignment
-                        self.state[table][column] = self.get_value(settings)
+                    # Single column assignment
+                    self.state[table][column] = self.get_value(settings)
 
     def write(self, file_format=None, overwrite=False):
         r'''Write pipeline results to disk.

--- a/skypy/pipeline/tests/test_pipeline.py
+++ b/skypy/pipeline/tests/test_pipeline.py
@@ -172,14 +172,8 @@ def test_multi_column_assignment_failure(na, nt):
 
 def test_pipeline_cosmology():
 
-    # Define function for testing pipeline cosmology
-    from skypy.utils import uses_default_cosmology
-
     def return_cosmology(cosmology):
         return cosmology
-
-    # Initial default_cosmology
-    initial_default = default_cosmology.get()
 
     # Test pipeline correctly sets default cosmology from parameters
     # N.B. astropy cosmology class has not implemented __eq__ for comparison
@@ -190,16 +184,12 @@ def test_pipeline_cosmology():
               }
     pipeline = Pipeline(config)
     pipeline.execute()
-    assert type(pipeline['test']) == FlatLambdaCDM
-    assert pipeline['test'].H0.value == H0
-    assert pipeline['test'].Om0 == Om0
+    assert pipeline['test'] is pipeline['cosmology']
 
     # Test pipeline correctly updates cosmology from new parameters
     H0_new, Om0_new = 75, 0.25
     pipeline.execute({'H0': H0_new, 'Om0': Om0_new})
-    assert type(pipeline['test']) == FlatLambdaCDM
-    assert pipeline['test'].H0.value == H0_new
-    assert pipeline['test'].Om0 == Om0_new
+    assert pipeline['test'] is pipeline['cosmology']
 
 
 def test_pipeline_read():

--- a/skypy/pipeline/tests/test_pipeline.py
+++ b/skypy/pipeline/tests/test_pipeline.py
@@ -175,7 +175,6 @@ def test_pipeline_cosmology():
     # Define function for testing pipeline cosmology
     from skypy.utils import uses_default_cosmology
 
-    @uses_default_cosmology
     def return_cosmology(cosmology):
         return cosmology
 
@@ -201,9 +200,6 @@ def test_pipeline_cosmology():
     assert type(pipeline['test']) == FlatLambdaCDM
     assert pipeline['test'].H0.value == H0_new
     assert pipeline['test'].Om0 == Om0_new
-
-    # Check that the astropy default cosmology is unchanged
-    assert default_cosmology.get() == initial_default
 
 
 def test_pipeline_read():


### PR DESCRIPTION
## Description

Instead of overriding `astropy.cosmology.default_cosmology`, this PR implements a system by which a `cosmology` argument of a function is set to `$cosmology` if the argument is not set. This happens statically when the pipeline is first constructed and should not add any overhead to the execution. The mechanism is easily extended to similar situations in the future.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request