### PR TITLE
Remove uses_default_cosmology decorator

### DIFF
--- a/docs/pipeline/examples/lightcone.yml
+++ b/docs/pipeline/examples/lightcone.yml
@@ -2,6 +2,7 @@ lightcone:
   z_min: 0.8
   z_max: 1.2
   n_slice: 4
+cosmology: !astropy.cosmology.default_cosmology.get
 tables:
   galaxies:
     redshift: !skypy.galaxy.redshift.schechter_lf_redshift

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -10,35 +10,8 @@ Decorators
 
 SkyPy provides a number of convenient decorators to perform common tasks:
 
-- :ref:`uses_default_cosmology`
 - :ref:`broadcast_arguments`
 - :ref:`dependent_argument`
-
-
-.. _uses_default_cosmology:
-
-Use the default cosmology
--------------------------
-
-The `uses_default_cosmology` decorator will check if a `cosmology` argument is
-provided, and if not, use the `astropy.cosmology.default_cosmology` instead.
-
-.. code-block:: python
-
-    from skypy.utils import uses_default_cosmology
-
-    @uses_default_cosmology
-    def a_function_with_cosmology(cosmology):
-        print('the comoving distance at z=1 is', cosmology.comoving_distance(1.))
-
-    # function can now be called without argument
-    a_function_with_cosmology()
-    # output: the comoving distance at z=1 is 3395.9053119753967 Mpc
-
-As shown in the example, the decorated function should treat the `cosmology`
-argument as a non-optional argument. Because the `uses_default_cosmology`
-decorator provides a required argument, it should always be placed above
-decorators which handle arguments.
 
 
 .. _broadcast_arguments:

--- a/examples/abundance_matching.yml
+++ b/examples/abundance_matching.yml
@@ -26,7 +26,6 @@ tables:
         wavenumber: $wavenumber
         power_spectrum: $power_spectrum
         growth_function: $growth_function
-        cosmology: $cosmology
       subhalo_kwargs:
         alpha: -1.91
         beta: 0.39
@@ -40,4 +39,3 @@ tables:
         alpha: -0.5
         m_lim: 35
         size: 1000
-        cosmology: $cosmology

--- a/examples/abundance_matching.yml
+++ b/examples/abundance_matching.yml
@@ -40,3 +40,4 @@ tables:
         alpha: -0.5
         m_lim: 35
         size: 1000
+        cosmology: $cosmology

--- a/skypy/galaxy/_schechter.py
+++ b/skypy/galaxy/_schechter.py
@@ -38,9 +38,8 @@ def schechter_lf(redshift, M_star, phi_star, alpha, m_lim, sky_area, cosmology, 
         Limiting apparent magnitude.
     sky_area : `~astropy.units.Quantity`
         Sky area over which galaxies are sampled. Must be in units of solid angle.
-    cosmology : Cosmology, optional
-        Cosmology object to convert apparent to absolute magnitudes. If not
-        given, the default cosmology is used.
+    cosmology : Cosmology
+        Cosmology object to convert apparent to absolute magnitudes.
     noise : bool, optional
         Poisson-sample the number of galaxies. Default is `True`.
 

--- a/skypy/galaxy/_schechter.py
+++ b/skypy/galaxy/_schechter.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 
-from ..utils import uses_default_cosmology
 from .redshift import schechter_lf_redshift
 from .luminosity import schechter_lf_magnitude
 from astropy import units
@@ -12,7 +11,6 @@ __all__ = [
 ]
 
 
-@uses_default_cosmology
 @units.quantity_input(sky_area=units.sr)
 def schechter_lf(redshift, M_star, phi_star, alpha, m_lim, sky_area, cosmology, noise=True):
     r'''Sample redshifts and magnitudes from a Schechter luminosity function.

--- a/skypy/galaxy/luminosity.py
+++ b/skypy/galaxy/luminosity.py
@@ -66,9 +66,8 @@ def distance_modulus(redshift, cosmology):
     ----------
     redshift : array_like
         Redshift of objects.
-    cosmology : Cosmology, optional
-        The cosmology from which the luminosity distance is taken. If not
-        given, the default cosmology is used.
+    cosmology : Cosmology
+        The cosmology from which the luminosity distance is taken.
 
     Returns
     -------
@@ -176,9 +175,8 @@ def schechter_lf_magnitude(redshift, M_star, alpha, m_lim, cosmology, size=None,
         each galaxy, or a function of galaxy redshift.
     m_lim : float
         Apparent magnitude limit.
-    cosmology : Cosmology, optional
-        Cosmology object for converting apparent and absolute magnitudes. If
-        no cosmology is given, the default cosmology is used.
+    cosmology : Cosmology
+        Cosmology object for converting apparent and absolute magnitudes.
     size : int, optional
         Explicit size for the sampling. If not given, one magnitude is sampled
         for each redshift.

--- a/skypy/galaxy/luminosity.py
+++ b/skypy/galaxy/luminosity.py
@@ -5,7 +5,7 @@ r"""Models of galaxy luminosities.
 import numpy as np
 
 from ..utils.random import schechter
-from ..utils import uses_default_cosmology, dependent_argument
+from ..utils import dependent_argument
 
 
 __all__ = [
@@ -59,7 +59,6 @@ def apparent_to_absolute_magnitude(apparent_magnitude, distance_modulus):
     return np.subtract(apparent_magnitude, distance_modulus)
 
 
-@uses_default_cosmology
 def distance_modulus(redshift, cosmology):
     '''Compute the distance modulus.
 
@@ -156,7 +155,6 @@ def absolute_magnitude_from_luminosity(luminosity, zeropoint=None):
     return -2.5*np.log10(luminosity) - zeropoint
 
 
-@uses_default_cosmology
 @dependent_argument('M_star', 'redshift')
 @dependent_argument('alpha', 'redshift')
 def schechter_lf_magnitude(redshift, M_star, alpha, m_lim, cosmology, size=None,
@@ -199,8 +197,9 @@ def schechter_lf_magnitude(redshift, M_star, alpha, m_lim, cosmology, size=None,
 
     >>> import numpy as np
     >>> from skypy.galaxy.luminosity import schechter_lf_magnitude
+    >>> from astropy.cosmology import Planck15
     >>> z = np.random.uniform(4.9, 5.1, size=20)
-    >>> M = schechter_lf_magnitude(z, -20.5, -1.3, 22.0)
+    >>> M = schechter_lf_magnitude(z, -20.5, -1.3, 22.0, Planck15)
 
     '''
 

--- a/skypy/galaxy/redshift.py
+++ b/skypy/galaxy/redshift.py
@@ -9,7 +9,7 @@ import scipy.integrate
 import scipy.special
 from astropy import units
 
-from ..utils import uses_default_cosmology, broadcast_arguments, dependent_argument
+from ..utils import broadcast_arguments, dependent_argument
 
 
 __all__ = [
@@ -73,7 +73,6 @@ def smail(z_median, alpha, beta, size=None):
     return g**(1/beta)
 
 
-@uses_default_cosmology
 @dependent_argument('M_star', 'redshift')
 @dependent_argument('phi_star', 'redshift')
 @dependent_argument('alpha', 'redshift')
@@ -127,12 +126,13 @@ def schechter_lf_redshift(redshift, M_star, phi_star, alpha, m_lim, sky_area,
 
     >>> from skypy.galaxy.redshift import schechter_lf_redshift
     >>> from astropy import units
+    >>> from astropy.cosmology import Planck15
     >>> z = [0., 5.]
     >>> M_star = -20.5
     >>> phi_star = 3.5e-3
     >>> alpha = -1.3
     >>> sky_area = 1*units.deg**2
-    >>> z_gal = schechter_lf_redshift(z, M_star, phi_star, alpha, 22, sky_area)
+    >>> z_gal = schechter_lf_redshift(z, M_star, phi_star, alpha, 22, sky_area, Planck15)
 
     '''
 
@@ -158,7 +158,6 @@ def schechter_lf_redshift(redshift, M_star, phi_star, alpha, m_lim, sky_area,
                                            sky_area=sky_area, cosmology=cosmology, noise=noise)
 
 
-@uses_default_cosmology
 @units.quantity_input(sky_area=units.sr)
 def redshifts_from_comoving_density(redshift, density, sky_area, cosmology, noise=True):
     r'''Sample redshifts from a comoving density function.
@@ -198,9 +197,10 @@ def redshifts_from_comoving_density(redshift, density, sky_area, cosmology, nois
 
     >>> from skypy.galaxy.redshift import redshifts_from_comoving_density
     >>> from astropy import units
+    >>> from astropy.cosmology import Planck15
     >>> z_range = np.arange(0, 1.01, 0.1)
     >>> sky_area = 1*units.deg**2
-    >>> z_gal = redshifts_from_comoving_density(z_range, 1e-3, sky_area)
+    >>> z_gal = redshifts_from_comoving_density(z_range, 1e-3, sky_area, Planck15)
 
     '''
 

--- a/skypy/galaxy/redshift.py
+++ b/skypy/galaxy/redshift.py
@@ -105,9 +105,8 @@ def schechter_lf_redshift(redshift, M_star, phi_star, alpha, m_lim, sky_area,
         Limiting apparent magnitude.
     sky_area : `~astropy.units.Quantity`
         Sky area over which galaxies are sampled. Must be in units of solid angle.
-    cosmology : Cosmology, optional
-        Cosmology object to convert apparent to absolute magnitudes. If not
-        given, the default cosmology is used.
+    cosmology : Cosmology
+        Cosmology object to convert apparent to absolute magnitudes.
     noise : bool, optional
         Poisson-sample the number of galaxies. Default is `True`.
 
@@ -178,9 +177,8 @@ def redshifts_from_comoving_density(redshift, density, sky_area, cosmology, nois
         Comoving galaxy number density at each redshift in Mpc-3.
     sky_area : `~astropy.units.Quantity`
         Sky area over which galaxies are sampled. Must be in units of solid angle.
-    cosmology : Cosmology, optional
-        Cosmology object for conversion to comoving volume. If not given, the
-        default cosmology is used.
+    cosmology : Cosmology
+        Cosmology object for conversion to comoving volume.
     noise : bool, optional
         Poisson-sample the number of galaxies. Default is `True`.
 

--- a/skypy/galaxy/size.py
+++ b/skypy/galaxy/size.py
@@ -6,8 +6,6 @@ This modules computes the angular size of galaxies from their physical size.
 import numpy as np
 from astropy import units
 
-from skypy.utils import uses_default_cosmology
-
 
 __all__ = [
     'angular_size',
@@ -17,7 +15,6 @@ __all__ = [
 ]
 
 
-@uses_default_cosmology
 def angular_size(physical_size, redshift, cosmology):
     """Angular size of a galaxy.
     This function transforms physical radius into angular distance, described

--- a/skypy/galaxy/tests/test_luminosity.py
+++ b/skypy/galaxy/tests/test_luminosity.py
@@ -24,7 +24,7 @@ def test_magnitude_functions():
     DM = cosmo.distmod(z).value
 
     # compare with function
-    np.testing.assert_allclose(distance_modulus(z), DM)
+    np.testing.assert_allclose(distance_modulus(z, cosmo), DM)
 
     # compute apparent magnitudes
     m = absolute_to_apparent_magnitude(M, DM)

--- a/skypy/galaxy/tests/test_schechter.py
+++ b/skypy/galaxy/tests/test_schechter.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from scipy.stats import kstest
+from astropy.cosmology import default_cosmology
 
 
 def test_schechter_lf():
@@ -19,9 +20,10 @@ def test_schechter_lf():
     alpha = -0.5
     m_lim = 30.
     sky_area = 1.0 * units.deg**2
+    cosmo = default_cosmology.get()
 
     # sample redshifts and magnitudes
-    z_gal, M_gal = schechter_lf(z, M_star, phi_star, alpha, m_lim, sky_area)
+    z_gal, M_gal = schechter_lf(z, M_star, phi_star, alpha, m_lim, sky_area, cosmo)
 
     # check length
     assert len(z_gal) == len(M_gal)
@@ -32,4 +34,4 @@ def test_schechter_lf():
     # sample s.t. arrays need to be interpolated
     # alpha array not yet supported
     with raises(NotImplementedError):
-        z_gal, M_gal = schechter_lf(z, M_star, phi_star, alpha, m_lim, sky_area)
+        z_gal, M_gal = schechter_lf(z, M_star, phi_star, alpha, m_lim, sky_area, cosmo)

--- a/skypy/halo/abundance_matching.py
+++ b/skypy/halo/abundance_matching.py
@@ -23,7 +23,7 @@ __all__ = [
 ]
 
 
-def vale_ostriker(halo_kwargs, subhalo_kwargs, galaxy_kwargs):
+def vale_ostriker(halo_kwargs, subhalo_kwargs, galaxy_kwargs, cosmology):
     """Vale & Ostriker abundance matching.
     Generate matched arrays of (sub)halos masses and galaxy absolute magnitudes
     following the abundance matching model in [1]_.
@@ -37,6 +37,9 @@ def vale_ostriker(halo_kwargs, subhalo_kwargs, galaxy_kwargs):
         and `~skypy.halo.mass.subhalo_mass_sampler`.
     galaxy_kwargs : dict
         Dictionary of keyword arguments for
+        `~skypy.galaxy.luminosity.schechter_lf_magnitude`.
+    cosmology : astropy.cosmology.Cosmology
+        Cosmology argument for `~skypy.halo.mass.press_schechter` and
         `~skypy.galaxy.luminosity.schechter_lf_magnitude`.
 
     Returns
@@ -56,7 +59,7 @@ def vale_ostriker(halo_kwargs, subhalo_kwargs, galaxy_kwargs):
     """
 
     # Sample halo and subhalo masses
-    halo_mass = press_schechter(**halo_kwargs)
+    halo_mass = press_schechter(**halo_kwargs, cosmology=cosmology)
     halo_mass[::-1].sort()  # Sort in-place from high to low for indexing
     n_subhalos = number_subhalos(halo_mass, **subhalo_kwargs)
     sampler_kwargs = {k: v for k, v in subhalo_kwargs.items() if k not in ['gamma_M', 'noise']}
@@ -80,7 +83,7 @@ def vale_ostriker(halo_kwargs, subhalo_kwargs, galaxy_kwargs):
     parent[n_halos:] = False
 
     # Sample galaxy magnitudes
-    magnitude = schechter_lf_magnitude(**galaxy_kwargs)
+    magnitude = schechter_lf_magnitude(**galaxy_kwargs, cosmology=cosmology)
     n_galaxies = len(magnitude)
 
     # Sort halos and galaxies by mass and magnitude

--- a/skypy/halo/tests/test_abundance_matching.py
+++ b/skypy/halo/tests/test_abundance_matching.py
@@ -32,7 +32,8 @@ def test_vale_ostriker():
                      'M_star': -21.07994198,
                      'alpha': -0.5,
                      'm_lim': 35,
-                     'size': 100, }
+                     'size': 100,
+                     'cosmology': cosmology, }
 
     mass, group, parent, mag = vale_ostriker(halo_kwargs, subhalo_kwargs, galaxy_kwargs)
 

--- a/skypy/halo/tests/test_abundance_matching.py
+++ b/skypy/halo/tests/test_abundance_matching.py
@@ -20,8 +20,7 @@ def test_vale_ostriker():
                    'size': 100,
                    'wavenumber': k,
                    'power_spectrum': Pk,
-                   'growth_function': 0.40368249700456954,
-                   'cosmology': cosmology, }
+                   'growth_function': 0.40368249700456954, }
     subhalo_kwargs = {'alpha': -1.91,
                       'beta': 0.39,
                       'gamma_M': 0.18,
@@ -32,10 +31,9 @@ def test_vale_ostriker():
                      'M_star': -21.07994198,
                      'alpha': -0.5,
                      'm_lim': 35,
-                     'size': 100,
-                     'cosmology': cosmology, }
+                     'size': 100, }
 
-    mass, group, parent, mag = vale_ostriker(halo_kwargs, subhalo_kwargs, galaxy_kwargs)
+    mass, group, parent, mag = vale_ostriker(halo_kwargs, subhalo_kwargs, galaxy_kwargs, cosmology)
 
     # Check monotonic mass-magnitude relation
     np.testing.assert_array_equal(np.argsort(mass)[::-1], np.argsort(mag))

--- a/skypy/utils/__init__.py
+++ b/skypy/utils/__init__.py
@@ -7,13 +7,10 @@ __all__ = []
 from . import random
 from . import special
 
-from ._decorators import (
-        broadcast_arguments, dependent_argument, uses_default_cosmology,
-        spectral_data_input)
+from ._decorators import broadcast_arguments, dependent_argument, spectral_data_input
 
 __all__ += [
     'broadcast_arguments',
     'dependent_argument',
-    'uses_default_cosmology',
     'spectral_data_input',
 ]

--- a/skypy/utils/_decorators.py
+++ b/skypy/utils/_decorators.py
@@ -70,20 +70,6 @@ def dependent_argument(dependent_arg, *independent_args):
     return decorator
 
 
-def uses_default_cosmology(function):
-    '''Decorator to use the Astropy default cosmology if none is given.'''
-    sig = signature(function)
-
-    @wraps(function)
-    def wrapper(*args, **kwargs):
-        given = sig.bind_partial(*args, **kwargs)
-        if 'cosmology' not in given.arguments:
-            given.arguments['cosmology'] = default_cosmology.get()
-        return function(*given.args, **given.kwargs)
-
-    return wrapper
-
-
 def spectral_data_input(**parameters):
     '''Decorator to load spectral data automatically and validate units.
 

--- a/skypy/utils/tests/test_decorators.py
+++ b/skypy/utils/tests/test_decorators.py
@@ -3,22 +3,6 @@ import pytest
 from skypy.galaxy.spectrum import HAS_SPECUTILS, HAS_SKYPY_DATA
 
 
-def test_uses_default_cosmology():
-
-    from astropy.cosmology import default_cosmology, WMAP9
-
-    from skypy.utils import uses_default_cosmology
-
-    @uses_default_cosmology
-    def function_with_cosmology(cosmology):
-        return cosmology
-
-    assert function_with_cosmology() == default_cosmology.get()
-
-    assert WMAP9 != default_cosmology.get()
-    assert function_with_cosmology(WMAP9) == WMAP9
-
-
 def test_broadcast_arguments():
 
     from pytest import raises


### PR DESCRIPTION
## Description
After #371, the `cosmology` variable can now be automatically passed to functions by the `Pipeline` class. The `uses_default_cosmology` decorator is therefore no longer required and can be removed.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] ~Write unit tests~
- [x] Write documentation strings
- [ ] ~Assign someone from your working team to review this pull request~
- [x] Assign someone from the infrastructure team to review this pull request
