### PR TITLE
use classy from pip for testing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ test =
     specutils
 all =
     camb
-    classy @ git+https://github.com/skypyproject/classy.git@v2.8.1#egg=classy
+    classy==2.8.*
     healpy
     skypy-data @ https://github.com/skypyproject/skypy-data/archive/master.tar.gz
     specutils


### PR DESCRIPTION
## Description

Install classy from PyPI instead of grabbing it from GitHub. Note that currently our CLASS tests fail with `classy==2.9.*` so here we pin to version `classy==2.8.*` in setup.cfg with the intention of refactoring the tests in the future for compatibility with different versions.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
