### PR TITLE
Lambda functions can be defined in config

### DIFF
--- a/skypy/pipeline/_config.py
+++ b/skypy/pipeline/_config.py
@@ -81,6 +81,14 @@ class SkyPyLoader(yaml.SafeLoader):
 
         return (function, args, kwargs)
 
+    def construct_lambda(self, node):
+
+        lambda_val = node.value
+
+        assign_lambda_to_temp = 'temp = lambda {}'.format(lambda_val)
+        exec(assign_lambda_to_temp, globals())
+        return temp
+
     def construct_quantity(self, node):
         value = self.construct_scalar(node)
         return Quantity(value)
@@ -88,6 +96,9 @@ class SkyPyLoader(yaml.SafeLoader):
 
 # constructor for generic functions
 SkyPyLoader.add_multi_constructor('!', SkyPyLoader.construct_function)
+
+# constructor for lambda functions
+SkyPyLoader.add_constructor('!lambda', SkyPyLoader.construct_lambda)
 
 # constructor for quantities
 SkyPyLoader.add_constructor('!quantity', SkyPyLoader.construct_quantity)

--- a/skypy/pipeline/tests/data/lambda_function.yml
+++ b/skypy/pipeline/tests/data/lambda_function.yml
@@ -1,0 +1,3 @@
+a: 0.5
+tau: !lambda 'a : 1. / a'
+twice: !lambda 'a : a * 2'

--- a/skypy/pipeline/tests/test_config.py
+++ b/skypy/pipeline/tests/test_config.py
@@ -65,3 +65,11 @@ def test_kwarg_must_be_strings():
     with pytest.raises(ValueError) as e:
         load_skypy_yaml(filename)
     assert("Invalid key found in config" in e.value.args[0])
+
+
+def test_lambda_functions():
+    filename = get_pkg_data_filename('data/lambda_function.yml')
+    config = load_skypy_yaml(filename)
+    a = config['a']
+    assert config['tau'](a) == 1. / a
+    assert config['twice'](a) == 1.0


### PR DESCRIPTION
## Description
Allow users to define lambda functions in their configs.  Resolve's #318 

## Checklist
- [ ] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [ ] Assign someone from the infrastructure team to review this pull request
