### PR TITLE
Drop skypy-data dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,14 +49,6 @@ The SkyPy library can then be imported from python:
 
     >>> import skypy
 
-SkyPy has a number of optional dependencies which can be installed separately.
-One of these is `skypy-data`_ which contains data such as photometric bandpasses
-required for some calculations in SkyPy. This can be installed with:
-
-.. code:: bash
-
-    $ pip install skypy-data@https://github.com/skypyproject/skypy-data/archive/master.tar.gz
-
 SkyPy also has a driver script that can run simulation pipelines from the
 command line. The `skypyproject/examples`_ repository contains sample
 configuration files that you can clone and run:
@@ -73,7 +65,6 @@ configuration files that you can clone and run:
 .. _conda: https://docs.conda.io/en/latest/
 .. _pytest: https://docs.pytest.org/en/stable/
 .. _skypyproject/examples: https://github.com/skypyproject/examples
-.. _skypy-data: https://github.com/skypyproject/skypy-data
 
 
 Contributing

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,14 +31,12 @@ console_scripts =
 test =
     pytest-astropy
     pytest-rerunfailures
-    skypy-data @ https://github.com/skypyproject/skypy-data/archive/master.tar.gz
     specutils
     speclite != 0.9
 all =
     camb
     classy==2.8.*
     healpy
-    skypy-data @ https://github.com/skypyproject/skypy-data/archive/master.tar.gz
     specutils
     speclite != 0.9
 docs =

--- a/skypy/galaxy/spectrum.py
+++ b/skypy/galaxy/spectrum.py
@@ -28,13 +28,6 @@ except ImportError:
 else:
     HAS_SPECLITE = True
 
-try:
-    __import__('skypy-data')
-except ImportError:
-    HAS_SKYPY_DATA = False
-else:
-    HAS_SKYPY_DATA = True
-
 
 def dirichlet_coefficients(redshift, alpha0, alpha1, z1=1., weight=None):
     r"""Dirichlet-distributed SED coefficients.

--- a/skypy/galaxy/tests/test_spectrum.py
+++ b/skypy/galaxy/tests/test_spectrum.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy.stats
 import pytest
-from skypy.galaxy.spectrum import HAS_SPECUTILS, HAS_SKYPY_DATA, HAS_SPECLITE
+from skypy.galaxy.spectrum import HAS_SPECUTILS, HAS_SPECLITE
 
 
 @pytest.mark.flaky
@@ -228,8 +228,8 @@ def test_stellar_mass_from_reference_band():
     np.testing.assert_allclose(stellar_mass, truth)
 
 
-@pytest.mark.skipif(not HAS_SPECUTILS or not HAS_SKYPY_DATA or not HAS_SPECLITE,
-                    reason='test requires specutils, skypy-data and speclite')
+@pytest.mark.skipif(not HAS_SPECUTILS or not HAS_SPECLITE,
+                    reason='test requires specutils and speclite')
 def test_load_spectral_data():
 
     from skypy.galaxy.spectrum import load_spectral_data

--- a/skypy/utils/tests/test_decorators.py
+++ b/skypy/utils/tests/test_decorators.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from skypy.galaxy.spectrum import HAS_SPECUTILS, HAS_SKYPY_DATA, HAS_SPECLITE
+from skypy.galaxy.spectrum import HAS_SPECUTILS, HAS_SPECLITE
 
 
 def test_broadcast_arguments():
@@ -67,8 +67,8 @@ def test_dependent_argument():
             pass
 
 
-@pytest.mark.skipif(not HAS_SPECUTILS or not HAS_SKYPY_DATA or not HAS_SPECLITE,
-                    reason='test requires specutils and skypy-data')
+@pytest.mark.skipif(not HAS_SPECUTILS or not HAS_SPECLITE,
+                    reason='test requires specutils and speclite')
 def test_spectral_data_input():
 
     from astropy import units


### PR DESCRIPTION
## Description
After #368 and #379 data for optical filters and template spectra are handled without using the [skypyproject/skypy-data](https://github.com/skypyproject/skypy-data) repository and we can therefore drop it as a dependency.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] ~Write unit tests~
- [ ] ~Write documentation strings~
- [ ] ~Assign someone from your working team to review this pull request~
- [x] Assign someone from the infrastructure team to review this pull request
