### PR TITLE
Require speclite version 0.11 or later

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,13 +32,13 @@ test =
     pytest-astropy
     pytest-rerunfailures
     specutils
-    speclite != 0.9
+    speclite>=0.11
 all =
     camb
     classy==2.8.*
     healpy
     specutils
-    speclite != 0.9
+    speclite>=0.11
 docs =
     sphinx-astropy
     healpy


### PR DESCRIPTION
## Description
Speclite versions 0.9 and 0.10 fail to install using pip with the same error:
```
TypeError: generate_version_py() missing 2 required positional arguments: 'packagename' and 'version'
```

and using version 0.8 raised a `DeprecationWarning` in our unit tests:
```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    class FilterSequence(collections.Sequence):
```

This pull request therefore updates the minimum required version of speclite to 0.11.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] ~Write unit tests~
- [ ] ~Write documentation strings~
- [ ] ~Assign someone from your working team to review this pull request~
- [x] Assign someone from the infrastructure team to review this pull request
