### PR TITLE
build docs for all galaxy.spectrum objects

### DIFF
--- a/docs/galaxy.rst
+++ b/docs/galaxy.rst
@@ -108,4 +108,5 @@ Reference/API
    :include-all-objects:
 .. automodapi:: skypy.galaxy.size
 .. automodapi:: skypy.galaxy.spectrum
+   :include-all-objects:
 .. automodapi:: skypy.galaxy.stellar_mass

--- a/skypy/galaxy/spectrum.py
+++ b/skypy/galaxy/spectrum.py
@@ -458,4 +458,4 @@ class KCorrectTemplates(SpectrumTemplates):
 
 
 kcorrect = KCorrectTemplates(hdu=1)
-kcorrect.__doc__ = '''Galaxy spectra from kcorrect smoothed templates.'''
+'''`KCorrectTemplates` using kcorrect smoothed templates.'''


### PR DESCRIPTION
The link to `kcorrect` did not show up. It should now.