### PR TITLE
add mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -12,7 +12,6 @@
 
 Adam Amara <adam.amara@phys.ethz.ch> adamamara <adamamara@penguin>
 Coleman Krawczyk <coleman.krawczyk@gmail.com> CKrawczyk
-Ian Harrison <itrharrison@gmail.com>
 Ian Harry <ian.harry@ligo.org> <iwharry@googlemail.com>
 Nicolas Tessore <n.tessore@ucl.ac.uk> <nicolas.tessore@manchester.ac.uk>
 Richard R <58728519+rrjbca@users.noreply.github.com> <rrjbca@users.noreply.github.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,18 @@
+# map commits to canonical names and email addresses
+
+# format is
+#   canonical name [<canonical email>] [commit name] <commit email>
+# where the commit values will be mapped to canonical ones; see
+#   man git-check-mailmap
+# for details
+
+# to update, check
+#   git log --format="%aN <%aE>" | sort -u
+# for incorrect or duplicate entries
+
+Adam Amara <adam.amara@phys.ethz.ch> adamamara <adamamara@penguin>
+Coleman Krawczyk <coleman.krawczyk@gmail.com> CKrawczyk
+Ian Harrison <itrharrison@gmail.com>
+Ian Harry <ian.harry@ligo.org> <iwharry@googlemail.com>
+Nicolas Tessore <n.tessore@ucl.ac.uk> <nicolas.tessore@manchester.ac.uk>
+Richard R <58728519+rrjbca@users.noreply.github.com> <rrjbca@users.noreply.github.com>


### PR DESCRIPTION
Adds a [mailmap](https://git-scm.com/docs/git-check-mailmap) to the repository. I have gone through and fixed current duplicates to what seemed like the intended canonical names and email addresses.