### PR TITLE
URLs for stable version on readthedocs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,9 @@ The full list of features can be found in the `SkyPy Documentation`_.
 If you use SkyPy for work or research presented in a publication please follow
 our `Citation Guidelines`_.
 
-.. _Galaxies: https://skypy.readthedocs.io/en/latest/galaxies.html
-.. _Pipelines: https://skypy.readthedocs.io/en/latest/pipeline/index.html
-.. _SkyPy Documentation: https://skypy.readthedocs.io/en/latest/
+.. _Galaxies: https://skypy.readthedocs.io/en/stable/galaxies.html
+.. _Pipelines: https://skypy.readthedocs.io/en/stable/pipeline/index.html
+.. _SkyPy Documentation: https://skypy.readthedocs.io/en/stable/
 .. _Citation Guidelines: CITATION.rst
 
 


### PR DESCRIPTION
## Description
Some urls in the README currently point to the "latest"  build on readthedocs. Instead they should point to the "stable" build.

## Checklist
- [ ] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [ ] Assign someone from the infrastructure team to review this pull request
