### PR TITLE
Write all tables to a single FITS/HDF5 file

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -53,6 +53,7 @@ Installing using pip or conda will automatically install or update these core
 dependencies if necessary. SkyPy also has a number of optional dependencies
 that enable additional features:
 
+- `h5py <https://www.h5py.org/>`_
 - `speclite <https://speclite.readthedocs.io/>`_
 
 To install SkyPy with all optional dependencies using pip:

--- a/docs/pipeline/index.rst
+++ b/docs/pipeline/index.rst
@@ -19,7 +19,7 @@ fits files:
 
 .. code-block:: bash
 
-    $ skypy examples/galaxies/sdss_photometry.yml --format fits
+    $ skypy examples/galaxies/sdss_photometry.yml -o sdss_photometry.fits
 
 Config files are written in YAML format and read using the
 `~skypy.pipeline.load_skypy_yaml` funciton. Each entry in the config specifices

--- a/docs/pipeline/index.rst
+++ b/docs/pipeline/index.rst
@@ -19,7 +19,7 @@ fits files:
 
 .. code-block:: bash
 
-    $ skypy examples/galaxies/sdss_photometry.yml -o sdss_photometry.fits
+    $ skypy examples/galaxies/sdss_photometry.yml sdss_photometry.fits
 
 Config files are written in YAML format and read using the
 `~skypy.pipeline.load_skypy_yaml` funciton. Each entry in the config specifices

--- a/examples/galaxies/plot_photometry.py
+++ b/examples/galaxies/plot_photometry.py
@@ -40,7 +40,7 @@ kcorrect spectral energy distribution templates as implemented in SkyPy.
 #
 # .. code-block:: bash
 #
-#    $ skypy examples/galaxies/sdss_photometry.yml -o sdss_photometry.fits
+#    $ skypy examples/galaxies/sdss_photometry.yml sdss_photometry.fits
 #
 # or in a python script using the :class:`Pipeline <skypy.pipeline.Pipeline>`
 # class as demonstrated in the `SDSS Photometry`_ section below. For more

--- a/examples/galaxies/plot_photometry.py
+++ b/examples/galaxies/plot_photometry.py
@@ -40,7 +40,7 @@ kcorrect spectral energy distribution templates as implemented in SkyPy.
 #
 # .. code-block:: bash
 #
-#    $ skypy examples/galaxies/sdss_photometry.yml --format fits
+#    $ skypy examples/galaxies/sdss_photometry.yml -o sdss_photometry.fits
 #
 # or in a python script using the :class:`Pipeline <skypy.pipeline.Pipeline>`
 # class as demonstrated in the `SDSS Photometry`_ section below. For more

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ test =
     pytest-rerunfailures
     speclite>=0.11
 all =
+    h5py
     speclite>=0.11
 docs =
     sphinx-astropy

--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -226,8 +226,8 @@ class Pipeline:
             If filename already exists, this flag indicates whether or not to
             overwrite it (without warning).
         '''
-        from astropy.io.fits import BinTableHDU, HDUList
-        hdul = [BinTableHDU(data=self.state[t], name=t) for t in self.table_config.keys()]
+        from astropy.io.fits import BinTableHDU, HDUList, PrimaryHDU
+        hdul = [PrimaryHDU()] + [BinTableHDU(data=self[t], name=t) for t in self.table_config]
         HDUList(hdul).writeto(filename, overwrite=overwrite)
 
     def write_hdf5(self, filename, overwrite=False):
@@ -242,8 +242,8 @@ class Pipeline:
             overwrite it (without warning).
         '''
         from astropy.io.misc.hdf5 import write_table_hdf5
-        for t in self.table_config.keys():
-            write_table_hdf5(self.state[t], filename, path=f'tables/{t}', overwrite=overwrite)
+        for t in self.table_config:
+            write_table_hdf5(self[t], filename, path=f'tables/{t}', overwrite=overwrite)
 
     def evaluate(self, value):
         '''evaluate an item in the pipeline'''

--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -209,6 +209,16 @@ class Pipeline:
                 filename = '.'.join((table, file_format))
                 self.state[table].write(filename, overwrite=overwrite)
 
+    def write_fits(self, filename, overwrite=False):
+        from astropy.io.fits import BinTableHDU, HDUList
+        hdul = [BinTableHDU(data=self.state[t], name=t) for t in self.table_config.keys()]
+        HDUList(hdul).writeto(filename, overwrite=overwrite)
+
+    def write_hdf5(self, filename, overwrite=False):
+        from astropy.io.misc.hdf5 import write_table_hdf5
+        for t in self.table_config.keys():
+            write_table_hdf5(self.state[t], filename, path=f'tables/{t}', overwrite=overwrite)
+
     def evaluate(self, value):
         '''evaluate an item in the pipeline'''
 

--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence, Mapping
 from ._config import load_skypy_yaml
 from ._items import Item, Call, Ref
 import networkx
+import pathlib
 
 
 __all__ = [
@@ -187,27 +188,32 @@ class Pipeline:
                     # Single column assignment
                     self.state[table][column] = self.evaluate(settings)
 
-    def write(self, file_format=None, overwrite=False):
+    def write(self, filename, overwrite=False):
         r'''Write pipeline results to disk.
 
         Parameters
         ----------
-        file_format : str
-            File format used to write tables. Files are written using the
-            Astropy unified file read/write interface; see [1]_ for supported
-            file formats. If None (default) tables are not written to file.
+        filename : str
+            Name of output file to be written. It must have one of the
+            supported file extensions for FITS (.fit .fits .fts) or HDF5
+            (.hdf5 .hd5 .he5 .h5).
         overwrite : bool
-            Whether to overwrite any existing files without warning.
-
-        References
-        ----------
-        .. [1] https://docs.astropy.org/en/stable/io/unified.html
-
+            If filename already exists, this flag indicates whether or not to
+            overwrite it (without warning).
         '''
-        if file_format:
-            for table in self.table_config.keys():
-                filename = '.'.join((table, file_format))
-                self.state[table].write(filename, overwrite=overwrite)
+
+        suffix = pathlib.Path(filename).suffix.lower()
+        _fits_suffixes = ('.fit', '.fits', '.fts')
+        _hdf5_suffixes = ('.hdf5', '.hd5', '.he5', '.h5')
+
+        if suffix in _fits_suffixes:
+            self.write_fits(filename, overwrite)
+        elif suffix in _hdf5_suffixes:
+            self.write_hdf5(filename, overwrite)
+        else:
+            raise ValueError(f'{suffix} is an unsupported file format. SkyPy supports '
+                              'FITS (' + ' '.join(_fits_suffixes) + ') and '
+                              'HDF5 (' + ' '.join(_hdf5_suffixes) + ').')
 
     def write_fits(self, filename, overwrite=False):
         from astropy.io.fits import BinTableHDU, HDUList

--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -241,9 +241,8 @@ class Pipeline:
             If filename already exists, this flag indicates whether or not to
             overwrite it (without warning).
         '''
-        from astropy.io.misc.hdf5 import write_table_hdf5
         for t in self.table_config:
-            write_table_hdf5(self[t], filename, path=f'tables/{t}', overwrite=overwrite)
+            self[t].write(filename, path=f'tables/{t}', append=True, overwrite=overwrite)
 
     def evaluate(self, value):
         '''evaluate an item in the pipeline'''

--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -212,8 +212,8 @@ class Pipeline:
             self.write_hdf5(filename, overwrite)
         else:
             raise ValueError(f'{suffix} is an unsupported file format. SkyPy supports '
-                              'FITS (' + ' '.join(_fits_suffixes) + ') and '
-                              'HDF5 (' + ' '.join(_hdf5_suffixes) + ').')
+                             'FITS (' + ' '.join(_fits_suffixes) + ') and '
+                             'HDF5 (' + ' '.join(_hdf5_suffixes) + ').')
 
     def write_fits(self, filename, overwrite=False):
         r'''Write pipeline results to a FITS file.

--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -216,11 +216,31 @@ class Pipeline:
                               'HDF5 (' + ' '.join(_hdf5_suffixes) + ').')
 
     def write_fits(self, filename, overwrite=False):
+        r'''Write pipeline results to a FITS file.
+
+        Parameters
+        ----------
+        filename : str
+            Name of output file to be written.
+        overwrite : bool
+            If filename already exists, this flag indicates whether or not to
+            overwrite it (without warning).
+        '''
         from astropy.io.fits import BinTableHDU, HDUList
         hdul = [BinTableHDU(data=self.state[t], name=t) for t in self.table_config.keys()]
         HDUList(hdul).writeto(filename, overwrite=overwrite)
 
     def write_hdf5(self, filename, overwrite=False):
+        r'''Write pipeline results to a HDF5 file.
+
+        Parameters
+        ----------
+        filename : str
+            Name of output file to be written.
+        overwrite : bool
+            If filename already exists, this flag indicates whether or not to
+            overwrite it (without warning).
+        '''
         from astropy.io.misc.hdf5 import write_table_hdf5
         for t in self.table_config.keys():
             write_table_hdf5(self.state[t], filename, path=f'tables/{t}', overwrite=overwrite)

--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -225,8 +225,12 @@ class Pipeline:
             If filename already exists, this flag indicates whether or not to
             overwrite it (without warning).
         '''
-        from astropy.io.fits import BinTableHDU, HDUList, PrimaryHDU
-        hdul = [PrimaryHDU()] + [BinTableHDU(data=self[t], name=t) for t in self.table_config]
+        from astropy.io.fits import HDUList, PrimaryHDU, table_to_hdu
+        hdul = [PrimaryHDU()]
+        for t in self.table_config:
+            hdu = table_to_hdu(self[t])
+            hdu.header['EXTNAME'] = t
+            hdul.append(hdu)
         HDUList(hdul).writeto(filename, overwrite=overwrite)
 
     def write_hdf5(self, filename, overwrite=False):

--- a/skypy/pipeline/scripts/skypy.py
+++ b/skypy/pipeline/scripts/skypy.py
@@ -11,8 +11,8 @@ def main(args=None):
     parser = argparse.ArgumentParser(description="SkyPy pipeline driver")
     parser.add_argument('--version', action='version', version=skypy_version)
     parser.add_argument('config', help='Config file name')
-    parser.add_argument('-o', '--output', required=False, help='Output file name')
-    parser.add_argument('-v', '--overwrite', action='store_true',
+    parser.add_argument('output', help='Output file name')
+    parser.add_argument('-o', '--overwrite', action='store_true',
                         help='Whether to overwrite existing files')
 
     # get system args if none passed
@@ -22,8 +22,13 @@ def main(args=None):
     args = parser.parse_args(args or ['--help'])
     config = load_skypy_yaml(args.config)
 
-    pipeline = Pipeline(config)
-    pipeline.execute()
-    if args.output:
-        pipeline.write(args.output, overwrite=args.overwrite)
+    try:
+        pipeline = Pipeline(config)
+        pipeline.execute()
+        if args.output:
+            pipeline.write(args.output, overwrite=args.overwrite)
+    except Exception as e:
+        print(e)
+        raise SystemExit(2) from e
+
     return(0)

--- a/skypy/pipeline/scripts/skypy.py
+++ b/skypy/pipeline/scripts/skypy.py
@@ -11,9 +11,8 @@ def main(args=None):
     parser = argparse.ArgumentParser(description="SkyPy pipeline driver")
     parser.add_argument('--version', action='version', version=skypy_version)
     parser.add_argument('config', help='Config file name')
-    parser.add_argument('-f', '--format', required=False,
-                        choices=['fits', 'hdf5'], help='Table file format')
-    parser.add_argument('-o', '--overwrite', action='store_true',
+    parser.add_argument('-o', '--output', required=False, help='Output file name')
+    parser.add_argument('-v', '--overwrite', action='store_true',
                         help='Whether to overwrite existing files')
 
     # get system args if none passed
@@ -25,5 +24,6 @@ def main(args=None):
 
     pipeline = Pipeline(config)
     pipeline.execute()
-    pipeline.write(file_format=args.format, overwrite=args.overwrite)
+    if args.output:
+        pipeline.write(args.output, overwrite=args.overwrite)
     return(0)

--- a/skypy/pipeline/tests/test_pipeline.py
+++ b/skypy/pipeline/tests/test_pipeline.py
@@ -36,17 +36,18 @@ def test_pipeline():
 
     pipeline = Pipeline(config)
     pipeline.execute()
-    pipeline.write(file_format='fits')
+    output_filename = 'output.fits'
+    pipeline.write(output_filename)
     assert len(pipeline['test_table']) == size
     assert np.all(pipeline['test_table.column1'] < pipeline['test_table.column2'])
-    with fits.open('test_table.fits') as hdu:
+    with fits.open(output_filename) as hdu:
         assert np.all(Table(hdu[1].data) == pipeline['test_table'])
 
     # Check for failure if output files already exist and overwrite is False
     pipeline = Pipeline(config)
     pipeline.execute()
     with pytest.raises(OSError):
-        pipeline.write(file_format='fits', overwrite=False)
+        pipeline.write(output_filename, overwrite=False)
 
     # Check that the existing output files are modified if overwrite is True
     new_size = 2 * size
@@ -55,8 +56,8 @@ def test_pipeline():
     config['tables']['test_table']['column3'].args = [new_string]
     pipeline = Pipeline(config)
     pipeline.execute()
-    pipeline.write(file_format='fits', overwrite=True)
-    with fits.open('test_table.fits') as hdu:
+    pipeline.write(output_filename, overwrite=True)
+    with fits.open(output_filename) as hdu:
         assert len(hdu[1].data) == new_size
 
     # Check for failure if 'column1' requires itself creating a cyclic
@@ -240,4 +241,4 @@ def test_column_quantity():
 def teardown_module(module):
 
     # Remove fits file generated in test_pipeline
-    os.remove('test_table.fits')
+    os.remove('output.fits')

--- a/skypy/pipeline/tests/test_skypy.py
+++ b/skypy/pipeline/tests/test_skypy.py
@@ -1,6 +1,7 @@
 from astropy.utils.data import get_pkg_data_filename
 from contextlib import redirect_stdout
 from io import StringIO
+import os
 import pytest
 from skypy import __version__ as skypy_version
 from skypy.pipeline.scripts import skypy
@@ -26,20 +27,27 @@ def test_skypy():
     assert version.getvalue().strip() == skypy_version
     assert e.value.code == 0
 
-    # Missing positional argument 'config'
+    # Missing positional argument 'output'
     with pytest.raises(SystemExit) as e:
-        skypy.main(['--output', 'output.fits'])
-    assert e.value.code == 2
-
-    # Invalid file format
-    with pytest.raises(SystemExit) as e:
-        skypy.main(['config.filename', 'output.invalid'])
+        skypy.main(['config.filename'])
     assert e.value.code == 2
 
     # Process empty config file
     filename = get_pkg_data_filename('data/empty_config.yml')
-    assert skypy.main([filename]) == 0
+    assert skypy.main([filename, 'empty.fits']) == 0
 
     # Process test config file
     filename = get_pkg_data_filename('data/test_config.yml')
-    assert skypy.main([filename]) == 0
+    assert skypy.main([filename, 'test.fits']) == 0
+
+    # Invalid file format
+    with pytest.raises(SystemExit) as e:
+        skypy.main([filename, 'test.invalid'])
+    assert e.value.code == 2
+
+
+def teardown_module(module):
+
+    # Remove fits file generated in test_skypy
+    os.remove('empty.fits')
+    os.remove('test.fits')

--- a/skypy/pipeline/tests/test_skypy.py
+++ b/skypy/pipeline/tests/test_skypy.py
@@ -28,12 +28,12 @@ def test_skypy():
 
     # Missing positional argument 'config'
     with pytest.raises(SystemExit) as e:
-        skypy.main(['--format', 'fits'])
+        skypy.main(['--output', 'output.fits'])
     assert e.value.code == 2
 
     # Invalid file format
     with pytest.raises(SystemExit) as e:
-        skypy.main(['--format', 'invalid', 'config.filename'])
+        skypy.main(['config.filename', 'output.invalid'])
     assert e.value.code == 2
 
     # Process empty config file


### PR DESCRIPTION
## Description
- The `skypy` command line script and `Pipeline.write` method now take the full name for the output file as an argument. The format of the file is inferred from lists of allowed extensions.
- `Pipeline.write` now writes all tables to a single file. For a FITS file each table is written to a separate named HDU. For a HDF5 file each table is written to a separate path with the format `tables/<table name>`
- Docstrings and unit tests updated to reflect these changes.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [x] Write unit tests
- [x] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
