### PR TITLE
fetch-depth zero

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,8 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Install Python ${{ matrix.python }}
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
## Description
Set `fetch-depth: 0` when configuring `actions/checkout@v2` to ensure commit SHAs are detectable. 

Previous error message during "Upload coverage to codecov" step:
`Issue detecting commit SHA. Please run actions/checkout with fetch-depth > 1 or set to 0`

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
