### PR TITLE
Code style status check using flake8

### DIFF
--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -9,7 +9,7 @@ on:
     - master
     - module/*
 jobs:
-  codestyle:
+  flake8:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository

--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -1,0 +1,26 @@
+name: Code Style
+on:
+  push:
+    branches:
+    - master
+    - module/*
+  pull_request:
+    branches:
+    - master
+    - module/*
+jobs:
+  codestyle:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+    - name: Install Python 3.x
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+    - name: Install Dependencies
+      run: |
+        pip install tox
+    - name: Check Code Style
+      run: |
+        tox -e codestyle

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,10 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: code style
-            os: ubuntu-latest
-            python: 3.x
-            toxenv: codestyle
 
           - name: latest supported versions
             os: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Code Style
+          - name: code style
             os: ubuntu-latest
             python: 3.x
             toxenv: codestyle

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,6 +16,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: Code Style
+            os: ubuntu-latest
+            python: 3.x
+            toxenv: codestyle
 
           - name: latest supported versions
             os: ubuntu-latest

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -84,7 +84,7 @@ Status checks
 A series of automated checks will be run on your pull request, some of which will be required to pass before it can be merged into the main codebase:
 
   - ``Tests`` (Required) runs the `unit tests`_ in four predefined environments; `latest supported versions`, `oldest supported versions`, `macOS latest supported` and `Windows latest supported`. Click "Details" to view the output including any failures.
-  - ``code style`` (Required) runs `flake8 <https://flake8.pycqa.org/en/latest/>`__ to check that your code conforms to the `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ style guidelines. Click "Details" to view any errors.
+  - ``Code Style`` (Required) runs `flake8 <https://flake8.pycqa.org/en/latest/>`__ to check that your code conforms to the `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ style guidelines. Click "Details" to view any errors.
   - ``codecov`` reports the test coverage for your pull request; you should aim for `codecov/patch — 100.00%`. Click "Details" to view coverage data.
   - ``docs`` (Required) builds the `docstrings`_ on `readthedocs <https://readthedocs.org/>`_. Click "Details" to view the documentation or the failed build log.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -84,7 +84,7 @@ Status checks
 A series of automated checks will be run on your pull request, some of which will be required to pass before it can be merged into the main codebase:
 
   - ``Tests`` (Required) runs the `unit tests`_ in four predefined environments; `latest supported versions`, `oldest supported versions`, `macOS latest supported` and `Windows latest supported`. Click "Details" to view the output including any failures.
-  - ``codeclimate`` (Required) runs `pycodestyle <https://pycodestyle.pycqa.org/en/latest/>`_ to check that your code conforms to the `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ style guidelines. Click "Details" to view any errors.
+  - ``Code Style`` (Required) runs `flake8 <https://flake8.pycqa.org/en/latest/>`_ to check that your code conforms to the `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ style guidelines. Click "Details" to view any errors.
   - ``codecov`` reports the test coverage for your pull request; you should aim for `codecov/patch — 100.00%`. Click "Details" to view coverage data.
   - ``docs`` (Required) builds the `docstrings`_ on `readthedocs <https://readthedocs.org/>`_. Click "Details" to view the documentation or the failed build log.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -84,7 +84,7 @@ Status checks
 A series of automated checks will be run on your pull request, some of which will be required to pass before it can be merged into the main codebase:
 
   - ``Tests`` (Required) runs the `unit tests`_ in four predefined environments; `latest supported versions`, `oldest supported versions`, `macOS latest supported` and `Windows latest supported`. Click "Details" to view the output including any failures.
-  - ``Code Style`` (Required) runs `flake8 <https://flake8.pycqa.org/en/latest/>`__ to check that your code conforms to the `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ style guidelines. Click "Details" to view any errors.
+  - ``code style`` (Required) runs `flake8 <https://flake8.pycqa.org/en/latest/>`__ to check that your code conforms to the `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ style guidelines. Click "Details" to view any errors.
   - ``codecov`` reports the test coverage for your pull request; you should aim for `codecov/patch — 100.00%`. Click "Details" to view coverage data.
   - ``docs`` (Required) builds the `docstrings`_ on `readthedocs <https://readthedocs.org/>`_. Click "Details" to view the documentation or the failed build log.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -84,7 +84,7 @@ Status checks
 A series of automated checks will be run on your pull request, some of which will be required to pass before it can be merged into the main codebase:
 
   - ``Tests`` (Required) runs the `unit tests`_ in four predefined environments; `latest supported versions`, `oldest supported versions`, `macOS latest supported` and `Windows latest supported`. Click "Details" to view the output including any failures.
-  - ``Code Style`` (Required) runs `flake8 <https://flake8.pycqa.org/en/latest/>`_ to check that your code conforms to the `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ style guidelines. Click "Details" to view any errors.
+  - ``Code Style`` (Required) runs `flake8 <https://flake8.pycqa.org/en/latest/>`__ to check that your code conforms to the `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ style guidelines. Click "Details" to view any errors.
   - ``codecov`` reports the test coverage for your pull request; you should aim for `codecov/patch — 100.00%`. Click "Details" to view coverage data.
   - ``docs`` (Required) builds the `docstrings`_ on `readthedocs <https://readthedocs.org/>`_. Click "Details" to view the documentation or the failed build log.
 
@@ -130,7 +130,7 @@ General Guidelines
 ^^^^^^^^^^^^^^^^^^
 
 - SkyPy is compatible with Python>=3.6 (see `setup.cfg <https://github.com/skypyproject/skypy/blob/master/setup.cfg>`_). SkyPy *does not* support backwards compatibility with Python 2.x; `six`, `__future__` and `2to3` should not be used.
-- All contributions should follow the `PEP8 Style Guide for Python Code <https://www.python.org/dev/peps/pep-0008/>`_. We recommend using `flake8 <https://flake8.pycqa.org/>`_ to check your code for PEP8 compliance.
+- All contributions should follow the `PEP8 Style Guide for Python Code <https://www.python.org/dev/peps/pep-0008/>`_. We recommend using `flake8 <https://flake8.pycqa.org/>`__ to check your code for PEP8 compliance.
 - Importing SkyPy should only depend on having `NumPy <https://www.numpy.org>`_, `SciPy <https://www.scipy.org/>`_ and `Astropy <https://www.astropy.org/>`__ installed.
 - Code is grouped into submodules based on broad science areas e.g. `galaxies <https://skypy.readthedocs.io/en/stable/galaxies.html>`_. There is also a `utils <https://skypy.readthedocs.io/en/stable/utils/index.html>`_ submodule for general utility functions.
 - For more information see the `Astropy Coding Guidelines <http://docs.astropy.org/en/latest/development/codeguide.html>`_.

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,5 +83,5 @@ exclude_lines =
     # Don't complain about IPython completion helper
     def _ipython_key_completions_
 
-[pep8]
+[flake8]
 max-line-length = 100

--- a/tox.ini
+++ b/tox.ini
@@ -109,7 +109,7 @@ commands =
 
 [testenv:codestyle]
 skip_install = true
-changedir = {toxinidir}
+changedir = .
 description = check code style, e.g. with flake8
 deps = flake8
 commands = flake8 skypy

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ envlist =
     py{36,37,38,39}-test-astropy{40,41,42}
     build_docs
     linkcheck
+    codestyle
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
@@ -105,3 +106,10 @@ extras = docs
 commands =
     pip freeze
     sphinx-build -W -b linkcheck . _build/html
+
+[testenv:codestyle]
+skip_install = true
+changedir = {toxinidir}
+description = check code style, e.g. with flake8
+deps = flake8
+commands = flake8 skypy


### PR DESCRIPTION
## Description
Run code style status check using [`flake8`](https://flake8.pycqa.org/en/latest/) in our GitHub tests workflow as implemented in the latest astropy cookiecutter template. Propose that this replaces codeclimate which uses pycodestyle and therefore cannot detect [PyFlake warnings](https://flake8.pycqa.org/en/2.6.0/warnings.html) e.g. `F401 'module' imported but unused`.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
