### PR TITLE
Fix flake8 code style errors

### DIFF
--- a/skypy/galaxies/stellar_mass.py
+++ b/skypy/galaxies/stellar_mass.py
@@ -4,7 +4,6 @@
 import numpy as np
 
 from ..utils.random import schechter
-from ..utils import broadcast_arguments, dependent_argument
 
 
 __all__ = [

--- a/skypy/galaxies/tests/test_import.py
+++ b/skypy/galaxies/tests/test_import.py
@@ -1,7 +1,7 @@
 def test_import():
-    import skypy.galaxies
-    import skypy.galaxies.luminosity
-    import skypy.galaxies.morphology
-    import skypy.galaxies.redshift
-    import skypy.galaxies.spectrum
-    import skypy.galaxies.stellar_mass
+    import skypy.galaxies  # noqa: F401
+    import skypy.galaxies.luminosity  # noqa: F401
+    import skypy.galaxies.morphology  # noqa: F401
+    import skypy.galaxies.redshift  # noqa: F401
+    import skypy.galaxies.spectrum  # noqa: F401
+    import skypy.galaxies.stellar_mass  # noqa: F401

--- a/skypy/galaxies/tests/test_redshift.py
+++ b/skypy/galaxies/tests/test_redshift.py
@@ -75,7 +75,8 @@ def test_schechter_smf_redshift():
     sky_area = 1.0 * units.deg**2
 
     # sample redshifts
-    z_gal = schechter_smf_redshift(z, m_star, phi_star, alpha, m_min, m_max, sky_area, cosmo, noise=False)
+    z_gal = schechter_smf_redshift(z, m_star, phi_star, alpha, m_min, m_max,
+                                   sky_area, cosmo, noise=False)
 
     # density with factor from upper incomplete gamma function
     density = phi_star*gamma(alpha+1)*gammaincc(alpha+1, m_min / m_star)

--- a/skypy/galaxies/tests/test_schechter.py
+++ b/skypy/galaxies/tests/test_schechter.py
@@ -1,6 +1,4 @@
 import numpy as np
-import pytest
-from scipy.stats import kstest
 from astropy.cosmology import default_cosmology
 
 

--- a/skypy/galaxies/tests/test_stellar_mass.py
+++ b/skypy/galaxies/tests/test_stellar_mass.py
@@ -12,9 +12,8 @@ from skypy.utils import special
 def test_exponential_distribution():
     # When alpha=0, M*=1 and x_min~0 we get a truncated exponential
     q_max = 1e2
-    sample = stellar_mass.schechter_smf_mass(0, 0, 1, size=1000,
-                                        m_min=1e-10, m_max=q_max,
-                                        resolution=1000)
+    sample = stellar_mass.schechter_smf_mass(0, 0, 1, size=1000, m_min=1e-10,
+                                             m_max=q_max, resolution=1000)
     d, p_value = scipy.stats.kstest(sample, 'truncexpon', args=(q_max,))
     assert p_value >= 0.01
 
@@ -57,8 +56,7 @@ def test_stellar_masses():
     m_star = 10 ** 10.67
     m_min = 10 ** 7
     m_max = 10 ** 13
-    sample = stellar_mass.schechter_smf_mass(0., -1.4, m_star, m_min,
-                                        m_max, size=1000,
-                                        resolution=100)
+    sample = stellar_mass.schechter_smf_mass(0., -1.4, m_star, m_min, m_max,
+                                             size=1000, resolution=100)
     p_value = scipy.stats.kstest(sample, calc_cdf)[1]
     assert p_value >= 0.01

--- a/skypy/pipeline/_pipeline.py
+++ b/skypy/pipeline/_pipeline.py
@@ -4,7 +4,6 @@ This module provides methods to run pipelines of functions with dependencies
 and handle their results.
 """
 
-from astropy.cosmology import default_cosmology
 from astropy.table import Table, Column
 from copy import copy, deepcopy
 from collections.abc import Sequence, Mapping

--- a/skypy/pipeline/tests/test_config.py
+++ b/skypy/pipeline/tests/test_config.py
@@ -35,7 +35,7 @@ def test_load_skypy_yaml():
 def test_empty_ref():
     filename = get_pkg_data_filename('data/test_empty_ref.yml')
     with pytest.raises(ValueError, match='empty reference'):
-        config = load_skypy_yaml(filename)
+        load_skypy_yaml(filename)
 
 
 def test_yaml_quantities():

--- a/skypy/pipeline/tests/test_import.py
+++ b/skypy/pipeline/tests/test_import.py
@@ -1,2 +1,2 @@
 def test_import():
-    import skypy.pipeline
+    import skypy.pipeline  # noqa: F401

--- a/skypy/tests/test_import.py
+++ b/skypy/tests/test_import.py
@@ -1,2 +1,2 @@
 def test_import():
-    import skypy
+    import skypy  # noqa: F401

--- a/skypy/utils/__init__.py
+++ b/skypy/utils/__init__.py
@@ -4,9 +4,9 @@ This module contains utility functions.
 
 __all__ = []
 
-from . import photometry
-from . import random
-from . import special
+from . import photometry  # noqa: F401
+from . import random  # noqa: F401
+from . import special  # noqa: F401
 
 from ._decorators import broadcast_arguments, dependent_argument
 

--- a/skypy/utils/_decorators.py
+++ b/skypy/utils/_decorators.py
@@ -5,8 +5,6 @@ import numpy as np
 
 from inspect import signature
 from functools import wraps
-from astropy import units
-from astropy.cosmology import default_cosmology
 
 
 def broadcast_arguments(*broadcast_args):

--- a/skypy/utils/tests/test_decorators.py
+++ b/skypy/utils/tests/test_decorators.py
@@ -1,6 +1,4 @@
 import numpy as np
-import pytest
-from skypy.utils.photometry import HAS_SPECLITE
 
 
 def test_broadcast_arguments():

--- a/skypy/utils/tests/test_import.py
+++ b/skypy/utils/tests/test_import.py
@@ -1,4 +1,4 @@
 def test_import():
-    import skypy.utils
-    import skypy.utils.random
-    import skypy.utils.special
+    import skypy.utils  # noqa: F401
+    import skypy.utils.random  # noqa: F401
+    import skypy.utils.special  # noqa: F401

--- a/skypy/utils/tests/test_photometry.py
+++ b/skypy/utils/tests/test_photometry.py
@@ -6,8 +6,8 @@ from skypy.utils.photometry import HAS_SPECLITE
 def test_magnitude_functions():
 
     from skypy.utils.photometry import (luminosity_in_band,
-            luminosity_from_absolute_magnitude,
-            absolute_magnitude_from_luminosity)
+                                        luminosity_from_absolute_magnitude,
+                                        absolute_magnitude_from_luminosity)
 
     # convert between absolute luminosity and magnitude
     assert np.isclose(luminosity_from_absolute_magnitude(-22), 630957344.5)


### PR DESCRIPTION
## Description
Fix style throughout the codebase such that `flake8 skypy --max-line-length=100` returns no errors. This will allow us to use `flake8` for our CI checks as in #427

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
