### PR TITLE
DOC: Remove docstring examples

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -150,7 +150,6 @@ All public classes, methods and functions require docstrings. You can build docu
   - Description
   - Parameters
   - Notes
-  - Examples
   - References
 
 For more information see the Astropy guide to `Writing Documentation <https://docs.astropy.org/en/stable/development/docguide.html>`_.

--- a/skypy/galaxies/luminosity.py
+++ b/skypy/galaxies/luminosity.py
@@ -46,18 +46,6 @@ def schechter_lf_magnitude(redshift, M_star, alpha, m_lim, cosmology, size=None,
         Absolute magnitude sampled from a Schechter luminosity function for
         each input galaxy redshift.
 
-    Examples
-    --------
-
-    Sample a number of blue (alpha = -1.3, M_star = -20.5) galaxy magnitudes
-    brighter than m = 22.0 around redshift 0.5.
-
-    >>> import numpy as np
-    >>> from skypy.galaxies.luminosity import schechter_lf_magnitude
-    >>> from astropy.cosmology import Planck15
-    >>> z = np.random.uniform(4.9, 5.1, size=20)
-    >>> M = schechter_lf_magnitude(z, -20.5, -1.3, 22.0, Planck15)
-
     '''
 
     # only alpha scalars supported at the moment

--- a/skypy/galaxies/morphology.py
+++ b/skypy/galaxies/morphology.py
@@ -40,13 +40,6 @@ def angular_size(physical_size, redshift, cosmology):
     angular_size : astropy.Quantity
         Angular distances in units of [rad] for a given radius.
 
-    Examples
-    --------
-    >>> from astropy import units
-    >>> from skypy.galaxies.morphology import angular_size
-    >>> from astropy.cosmology import Planck15
-    >>> r = angular_size(10*units.kpc, 1, Planck15)
-
     References
     ----------
     .. [1] D. W. Hogg, (1999), astro-ph/9905116.
@@ -89,14 +82,6 @@ def beta_ellipticity(e_ratio, e_sum, size=None):
     ----------
     .. [1] Kacprzak T., Herbel J., Nicola A. et al., arXiv:1906.01018
 
-    Examples
-    --------
-    Sample 10000 random variates from the Kacprzak model with
-    :math:`e_{\rm ratio} = 0.5` and :math:`e_{\rm sum} = 1.0`:
-
-    >>> from skypy.galaxies.morphology import beta_ellipticity
-    >>> ellipticity = beta_ellipticity(0.5, 1.0, size=10000)
-
     '''
 
     # convert to beta distribution parameters
@@ -138,17 +123,6 @@ def late_type_lognormal_size(magnitude, alpha, beta, gamma, M0, sigma1, sigma2,
         If size is ns, different from None, and magnitude is scalar,
         shape is (ns,). If magnitude has shape (nm,) and size=None,
         shape is (nm,).
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from skypy.galaxies import morphology
-    >>> magnitude = -16.0
-    >>> alpha, beta, gamma, M0 = 0.21, 0.53, -1.31, -20.52
-    >>> sigma1, sigma2 = 0.48, 0.25
-    >>> s = morphology.late_type_lognormal_size(magnitude, alpha, beta, gamma,
-    ...                                         M0, sigma1, sigma2)
-
 
     References
     ----------
@@ -200,17 +174,6 @@ def early_type_lognormal_size(magnitude, a, b, M0, sigma1, sigma2, size=None):
         shape is (ns,). If magnitude has shape (nm,) and size=None,
         shape is (nm,).
 
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from skypy.galaxies import morphology
-    >>> magnitude = -20.0
-    >>> a, b, M0 = 0.6, -4.63, -20.52
-    >>> sigma1, sigma2 = 0.48, 0.25
-    >>> s = morphology.early_type_lognormal_size(magnitude, a, b, M0, sigma1,
-    ...                                          sigma2)
-
-
     References
     ----------
     .. [1] S. Shen, H.J. Mo, S.D.M. White, M.R. Blanton, G. Kauffmann, W. Voges,
@@ -253,14 +216,6 @@ def linear_lognormal_size(magnitude, a_mu, b_mu, sigma, size=None):
         shape is (ns,). If magnitude has shape (nm,) and size=None,
         shape is (nm,).
 
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from skypy.galaxies import morphology
-    >>> magnitude = -20.0
-    >>> a_mu, b_mu, sigma =-0.24, -4.63, 0.4
-    >>> s = morphology.linear_lognormal_size(magnitude, a_mu, b_mu, sigma)
-
     References
     ----------
     .. [1] J. Herbel, T. Kacprzak, A. Amara, A. Refregier, C.Bruderer and
@@ -299,15 +254,6 @@ def ryden04_ellipticity(mu_gamma, sigma_gamma, mu, sigma, size=None):
     References
     ----------
     .. [1] Ryden B. S., 2004, ApJ, 601, 214
-
-    Examples
-    --------
-    Sample 10000 random variates from the Ryden (2004) model with parameters
-    :math:`\mu_\gamma = 0.222`, :math:`\sigma_\gamma = 0.056`,
-    :math:`\mu = -1.85`, and :math:`\sigma = 0.89`.
-
-    >>> from skypy.galaxies.morphology import ryden04_ellipticity
-    >>> ellipticity = ryden04_ellipticity(0.222, 0.056, -1.85, 0.89, size=10000)
 
     '''
 

--- a/skypy/galaxies/redshift.py
+++ b/skypy/galaxies/redshift.py
@@ -58,14 +58,6 @@ def smail(z_median, alpha, beta, size=None):
     .. [1] Smail I., Ellis R. S., Fitchett M. J., 1994, MNRAS, 270, 245
     .. [2] Amara A., Refregier A., 2007, MNRAS, 381, 1018
 
-    Examples
-    --------
-    Sample 10 random variates from the Smail model with `alpha = 1.5` and
-    `beta = 2` and median redshift `z_median = 1.2`.
-
-    >>> from skypy.galaxies.redshift import smail
-    >>> redshift = smail(1.2, 1.5, 2.0, size=10)
-
     '''
 
     k = (alpha+1)/beta
@@ -116,23 +108,6 @@ def schechter_lf_redshift(redshift, M_star, phi_star, alpha, m_lim, sky_area,
     redshifts : array_like
         Redshifts of the galaxy sample described by the Schechter luminosity
         function.
-
-    Examples
-    --------
-    Compute the number density of galaxies with redshifts between 0 and 5
-    for typical values of the "blue" galaxy luminosity function above an
-    apparent magnitude cut of 22 for a survey of 1 square degree = 1/41253 of
-    the sky.
-
-    >>> from skypy.galaxies.redshift import schechter_lf_redshift
-    >>> from astropy import units
-    >>> from astropy.cosmology import Planck15
-    >>> z = [0., 5.]
-    >>> M_star = -20.5
-    >>> phi_star = 3.5e-3
-    >>> alpha = -1.3
-    >>> sky_area = 1*units.deg**2
-    >>> z_gal = schechter_lf_redshift(z, M_star, phi_star, alpha, 22, sky_area, Planck15)
 
     '''
 
@@ -259,18 +234,6 @@ def redshifts_from_comoving_density(redshift, density, sky_area, cosmology, nois
     redshifts : array_like
         Sampled redshifts such that the comoving number density of galaxies
         corresponds to the input distribution.
-
-    Examples
-    --------
-    Sample redshifts with a constant comoving number density 1e-3/Mpc3 up to
-    redshift 1 for a survey of 1 square degree = 1/41253 of the sky.
-
-    >>> from skypy.galaxies.redshift import redshifts_from_comoving_density
-    >>> from astropy import units
-    >>> from astropy.cosmology import Planck15
-    >>> z_range = np.arange(0, 1.01, 0.1)
-    >>> sky_area = 1*units.deg**2
-    >>> z_gal = redshifts_from_comoving_density(z_range, 1e-3, sky_area, Planck15)
 
     '''
 

--- a/skypy/galaxies/spectrum.py
+++ b/skypy/galaxies/spectrum.py
@@ -73,20 +73,6 @@ def dirichlet_coefficients(redshift, alpha0, alpha1, z1=1., weight=None):
     .. [2] Blanton M. R., Roweis S., 2007, The Astronomical Journal,
            Volume 133, Page 734
 
-    Examples
-    --------
-    >>> from skypy.galaxies.spectrum import dirichlet_coefficients
-    >>> import numpy as np
-
-    Sample the coefficients according to [1]_ for n blue galaxies with
-    redshifts between 0 and 1.
-
-    >>> n = 100000
-    >>> alpha0 = np.array([2.079, 3.524, 1.917, 1.992, 2.536])
-    >>> alpha1 = np.array([2.265, 3.862, 1.921, 1.685, 2.480])
-    >>> redshift = np.linspace(0,2, n)
-    >>> coefficients = dirichlet_coefficients(redshift, alpha0, alpha1)
-
     """
 
     if np.ndim(alpha0) != 1 or np.ndim(alpha1) != 1:

--- a/skypy/utils/random.py
+++ b/skypy/utils/random.py
@@ -41,14 +41,6 @@ def schechter(alpha, x_min, x_max, resolution=100, size=None, scale=1.):
     x_sample : array_like
         Samples drawn from the Schechter function.
 
-    Examples
-    --------
-    >>> import skypy.utils.random as random
-    >>> alpha = -1.3
-    >>> sample = random.schechter(alpha, x_min=1e-10, x_max=1e2,
-    ...                           resolution=100, size=1000)
-
-
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Luminosity_function_(astronomy)

--- a/skypy/utils/special.py
+++ b/skypy/utils/special.py
@@ -70,15 +70,6 @@ def gammaincc(a, x):
     --------
     scipy.special.gammaincc : Computes the start of the recurrence.
 
-    Examples
-    --------
-    This implementation of `gammaincc` supports positive and negative values
-    of `a`.
-
-    >>> from skypy.utils.special import gammaincc
-    >>> gammaincc([-1.5, -0.5, 0.5, 1.5], 1.2)
-    array([ 0.03084582, -0.03378949,  0.12133525,  0.49363462])
-
     '''
     if np.broadcast(a, x).ndim == 0:
         return _gammaincc(a, x)


### PR DESCRIPTION
## Description
Removes all docstring examples. Currently they only demonstrate trivial call patterns which should be adequately described by the list of parameters in the docstrings for each function. Any more complex examples that are required should probably be added to the examples directory instead where text, plots and code examples can be better used to explain and demonstrate what the function is doing. Docstring examples are also currently run as part of the tests which is unnecessary given that the actual unit tests should all cover the same simple call patterns.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/master/CONTRIBUTING.md)
- [ ] Write unit tests
- [x] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
