### PR TITLE
update mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -13,5 +13,6 @@
 Adam Amara <adam.amara@phys.ethz.ch> adamamara <adamamara@penguin>
 Coleman Krawczyk <coleman.krawczyk@gmail.com> CKrawczyk
 Ian Harry <ian.harry@ligo.org> <iwharry@googlemail.com>
+Lucia F. de la Bella <55983939+Lucia-Fonseca@users.noreply.github.com>
 Nicolas Tessore <n.tessore@ucl.ac.uk> <nicolas.tessore@manchester.ac.uk>
 Richard R <58728519+rrjbca@users.noreply.github.com> <rrjbca@users.noreply.github.com>


### PR DESCRIPTION
fix duplicate author name for @Lucia-Fonseca, which showed up in our joss-paper submission

```
Author                     Commits    Insertions      Deletions    % of changes
Lucia F. de la Bella             1           126              0            0.55
Lucia-Fonseca                   15          1667            242            8.28
```