### PR TITLE
BUG: Raise ImportError if optional dependency speclite is not installed

### DIFF
--- a/skypy/utils/photometry.py
+++ b/skypy/utils/photometry.py
@@ -16,7 +16,7 @@ __all__ = [
 ]
 
 try:
-    import speclite.filters
+    import speclite.filters  # noqa F401
 except ImportError:
     HAS_SPECLITE = False
 else:
@@ -84,11 +84,12 @@ def mag_ab(wavelength, spectrum, filters, *, redshift=None, coefficients=None,
     .. [1] M. R. Blanton et al., 2003, AJ, 125, 2348
 
     '''
+    from speclite.filters import load_filters
 
     # load the filters
     if np.ndim(filters) == 0:
         filters = (filters,)
-    filters = speclite.filters.load_filters(*filters)
+    filters = load_filters(*filters)
     if np.shape(filters) == (1,):
         filters = filters[0]
 

--- a/skypy/utils/tests/test_photometry.py
+++ b/skypy/utils/tests/test_photometry.py
@@ -161,3 +161,17 @@ def test_template_spectra():
                                                   Planck15, resolution=2)
     np.testing.assert_allclose(m_true, m_interp, rtol=1e-5)
     assert not np.all(m_true == m_interp)
+
+
+@pytest.mark.skipif(HAS_SPECLITE, reason='test requires that speclite is not installed')
+def test_speclite_not_installed():
+    """
+    Regression test for #436
+    Test that mag_ab raises the correct exception if speclite is not insalled.
+    """
+    from skypy.utils.photometry import mag_ab
+    wavelength = np.linspace(1, 10, 100)
+    spectrum = np.ones(10)
+    filter = 'bessell-B'
+    with pytest.raises(ImportError):
+        mag_ab(wavelength, spectrum, filter)


### PR DESCRIPTION
## Description
Attempting to call `mag_ab` without the optional dependency `speclite` installed will now correctly raise an `ImportError` instead of a `NameError`. Fixes #436 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [x] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
