### PR TITLE
BUG: Fix configuration of CAMB interpolator redshift grid

### DIFF
--- a/skypy/power_spectrum/_camb.py
+++ b/skypy/power_spectrum/_camb.py
@@ -1,5 +1,6 @@
 import numpy as np
 from astropy import units
+from inspect import signature
 
 
 __all__ = [
@@ -85,7 +86,7 @@ def camb(wavenumber, redshift, cosmology, A_s, n_s):
 
     pars.NonLinear = model.NonLinear_none
 
-    if len(redshift) > 1:
+    if len(redshift) > signature(get_matter_power_interpolator).parameters['nz_step'].default:
         redshift_kwargs = {'zmin': np.min(redshift), 'zmax': np.max(redshift)}
     else:
         redshift_kwargs = {'zs': redshift}

--- a/skypy/power_spectrum/_camb.py
+++ b/skypy/power_spectrum/_camb.py
@@ -85,11 +85,16 @@ def camb(wavenumber, redshift, cosmology, A_s, n_s):
 
     pars.NonLinear = model.NonLinear_none
 
+    if len(redshift) > 1:
+        redshift_kwargs = {'zmin': np.min(redshift), 'zmax': np.max(redshift)}
+    else:
+        redshift_kwargs = {'zs': redshift}
+
     pk_interp = get_matter_power_interpolator(pars,
                                               nonlinear=False,
                                               hubble_units=False, k_hunit=False,
                                               kmax=np.max(wavenumber),
-                                              zmax=np.max(redshift))
+                                              **redshift_kwargs)
 
     pzk = pk_interp.P(redshift[redshift_order], wavenumber[wavenumber_order])
 

--- a/skypy/power_spectrum/tests/test_camb.py
+++ b/skypy/power_spectrum/tests/test_camb.py
@@ -36,3 +36,16 @@ def test_camb():
     pzk = camb(wavenumber, redshift, Planck15, 2.e-9, 0.965)
     assert pzk.shape == (len(redshift), len(wavenumber))
     assert allclose(pzk, test_pzk[np.argsort(redshift), :], rtol=1.e-4)
+
+
+@pytest.mark.skipif(CAMB_NOT_FOUND, reason='CAMB not found')
+def test_camb_redshift_zero():
+    """
+    Regression test for #438
+    Test that camb runs succesfully with redshift=0.0
+    """
+    from skypy.power_spectrum import camb
+    redshift = 0.0
+    wavenumber = np.logspace(-4.0, np.log10(2.0), 200)
+    pzk = camb(wavenumber, redshift, Planck15, 2.e-9, 0.965)
+    assert allclose(pzk, test_pzk[0], rtol=1.e-4)


### PR DESCRIPTION
## Description
Fixes configuration of the CAMB interpolator redshift grid so that the user can calculate the power spectrum for specifically `redshift = 0.0`. Fixes #438. More generally the exact power spectrum will be calculated if the number of redshifts requested is less than or equal to the CAMB default parameter `nz_step=100`, otherwise the exact power spectrum is interpolated from a grid of `nz_step` redshifts between `np.min(redshift)` and `np.max(redshift)`. 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [x] Write unit tests
- [ ] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
