### PR TITLE
MAINT: Set NumPy latest supported version to 1.20

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{36,37,38,39}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
-    py{36,37,38,39}-test-numpy{116,117,118,119}
+    py{36,37,38,39}-test-numpy{116,117,118,119,120}
     py{36,37,38,39}-test-scipy{12,13,14,15,16}
     py{36,37,38,39}-test-astropy{40,41,42}
     build_docs
@@ -42,6 +42,7 @@ description =
     numpy117: with numpy 1.17.*
     numpy118: with numpy 1.18.*
     numpy119: with numpy 1.19.*
+    numpy120: with numpy 1.20.*
     scipy12: with scipy 1.2.*
     scipy13: with scipy 1.3.*
     scipy14: with scipy 1.4.*
@@ -58,6 +59,7 @@ deps =
     numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*
     numpy119: numpy==1.19.*
+    numpy120: numpy==1.20.*
 
     scipy12: scipy==1.2.*
     scipy13: scipy==1.3.*
@@ -74,7 +76,7 @@ deps =
     dev: git+https://github.com/astropy/astropy.git#egg=astropy
 
     latest: astropy==4.2.*
-    latest: numpy==1.19.*
+    latest: numpy==1.20.*
     latest: scipy==1.6.*
 
     oldest: astropy==4.0.*


### PR DESCRIPTION
## Description
Set NumPy latest supported version to 1.20. Consistency tests are currently passing using NumPy 1.20.1.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
