### PR TITLE
DOC: Describe speclite filters in documentation

### DIFF
--- a/docs/galaxies.rst
+++ b/docs/galaxies.rst
@@ -63,6 +63,13 @@ Spectrum
 
 The following models are found in the `skypy.galaxies.spectrum` package.
 
+SkyPy uses the `speclite <https://speclite.readthedocs.io/>`_ package for
+photometric calculations. Some of the following functions take the names of
+photometric filters as an input parameter. Users can choose from the available
+`Speclite Filters <https://speclite.readthedocs.io/en/latest/filters.html>`_
+following the naming syntax described in `speclite.filters.load_filters`, or
+create their own named `speclite.filters.FilterResponse`.
+
 .. currentmodule:: skypy.galaxies.spectrum
 .. autosummary::
    :nosignatures:

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -126,14 +126,13 @@ Photometry (`skypy.utils.photometry`)
 This module contains methods that model spectral energy distributions and
 calculate photometric properties.
 
-Some of the following functions require a photometric filter as an input
-parameter. In SkyPy, we included the
-`speclite <https://speclite.readthedocs.io/>`_ package to enable different
-spectroscopic tasks
-(see `Dependencies <https://skypy.readthedocs.io/en/latest/install.html#dependencies>`_).
-One can choose between the available filters described
-`here <https://speclite.readthedocs.io/en/latest/filters.html>`_ by using the
-same syntax (see `speclite.filters.load_filters`).
+SkyPy uses the `speclite <https://speclite.readthedocs.io/>`_ package for
+photometric calculations. Some of the following functions take the names of
+photometric filters as an input parameter. Users can choose from the available
+`Speclite Filters <https://speclite.readthedocs.io/en/latest/filters.html>`_
+following the naming syntax described in `speclite.filters.load_filters`, or
+create their own named `speclite.filters.FilterResponse`.
+
 
 .. currentmodule:: skypy.utils.photometry
 .. autosummary::

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -126,6 +126,15 @@ Photometry (`skypy.utils.photometry`)
 This module contains methods that model spectral energy distributions and
 calculate photometric properties.
 
+Some of the following functions require a photometric filter as an input
+parameter. In SkyPy, we included the
+`speclite <https://speclite.readthedocs.io/>`_ package to enable different
+spectroscopic tasks
+(see `Dependencies <https://skypy.readthedocs.io/en/latest/install.html#dependencies>`_).
+One can choose between the available filters described
+`here <https://speclite.readthedocs.io/en/latest/filters.html>`_ by using the
+same syntax (see `speclite.filters.load_filters`).
+
 .. currentmodule:: skypy.utils.photometry
 .. autosummary::
    :nosignatures:


### PR DESCRIPTION
## Description
Addresses Issue #444. This PR adds a small description where to find the spectroscopic filter bands available as an input for the functions of the [Photometry module](https://github.com/skypyproject/skypy/blob/main/skypy/utils/photometry.py).

I added a link to the corresponding speclite documentation in the docs of the `Photometry` module.

## Checklist
- [ ] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Assign someone from the infrastructure team to review this pull request
