### PR TITLE
ENH: Config syntax for importing objects

### DIFF
--- a/examples/galaxies/sdss_photometry.yml
+++ b/examples/galaxies/sdss_photometry.yml
@@ -1,4 +1,4 @@
-cosmology: !astropy.cosmology.default_cosmology.get
+cosmology: !astropy.cosmology.default_cosmology.get []
 z_range: !numpy.linspace [0, 2, 21]
 M_star: !astropy.modeling.models.Linear1D [-0.9408582, -20.40492365]
 phi_star: !astropy.modeling.models.Exponential1D [0.00370253, -9.73858]

--- a/skypy/pipeline/_config.py
+++ b/skypy/pipeline/_config.py
@@ -68,7 +68,20 @@ class SkyPyLoader(yaml.SafeLoader):
         except (ModuleNotFoundError, AttributeError) as e:
             raise ImportError(f'{e}\n{node.start_mark}') from e
 
-        return Call(function, args, kwargs) if callable(function) else function
+        return Call(function, args, kwargs)
+
+    def construct_imported_object(self, node):
+        name = self.construct_scalar(node)
+        if name[:1] == '~':
+            name = name[1:]
+        if not name:
+            raise ValueError(f'empty object\n{node.start_mark}')
+        try:
+            object = import_function(name)
+        except (ModuleNotFoundError, AttributeError) as e:
+            raise ImportError(f'{e}\n{node.start_mark}') from e
+
+        return object
 
     def construct_quantity(self, node):
         value = self.construct_scalar(node)
@@ -82,6 +95,10 @@ SkyPyLoader.add_implicit_resolver('!ref', re.compile(r'\$\w+'), ['$'])
 
 # constructor for generic function calls
 SkyPyLoader.add_multi_constructor('!', SkyPyLoader.construct_call)
+
+# constructor for importing generic objects from external (sub)modules
+SkyPyLoader.add_constructor('!import', SkyPyLoader.construct_imported_object)
+SkyPyLoader.add_implicit_resolver('!import', re.compile(r'\~\w+'), ['~'])
 
 # constructor for quantities
 SkyPyLoader.add_constructor('!quantity', SkyPyLoader.construct_quantity)

--- a/skypy/pipeline/_config.py
+++ b/skypy/pipeline/_config.py
@@ -68,7 +68,7 @@ class SkyPyLoader(yaml.SafeLoader):
         except (ModuleNotFoundError, AttributeError) as e:
             raise ImportError(f'{e}\n{node.start_mark}') from e
 
-        return Call(function, args, kwargs)
+        return Call(function, args, kwargs) if callable(function) else function
 
     def construct_quantity(self, node):
         value = self.construct_scalar(node)

--- a/skypy/pipeline/_config.py
+++ b/skypy/pipeline/_config.py
@@ -58,6 +58,8 @@ class SkyPyLoader(yaml.SafeLoader):
             raise ImportError(f'{e}\n{node.start_mark}') from e
 
         if isinstance(node, yaml.ScalarNode):
+            if node.value:
+                raise ValueError(f'{node.value}: ScalarNode should be empty to import an object')
             return object
         else:
             if isinstance(node, yaml.SequenceNode):

--- a/skypy/pipeline/tests/data/bad_object.yml
+++ b/skypy/pipeline/tests/data/bad_object.yml
@@ -1,0 +1,1 @@
+bad_object: !astropy.cosmology.Planck15 "bad value"

--- a/skypy/pipeline/tests/data/test_config.yml
+++ b/skypy/pipeline/tests/data/test_config.yml
@@ -3,7 +3,7 @@ test_float: 1.0
 test_str: hello world
 test_func: !numpy.random.uniform []
 test_func_with_arg: !len ['hello world']
-test_object: !astropy.cosmology.Planck18
+test_object: !astropy.cosmology.Planck15
 cosmology: !astropy.cosmology.FlatLambdaCDM
   H0: 67.74
   Om0: 0.3075

--- a/skypy/pipeline/tests/data/test_config.yml
+++ b/skypy/pipeline/tests/data/test_config.yml
@@ -1,8 +1,9 @@
 test_int: 1
 test_float: 1.0
 test_str: hello world
-test_func: !numpy.random.uniform
-test_func_with_arg: !len 'hello world'
+test_func: !numpy.random.uniform []
+test_func_with_arg: !len ['hello world']
+test_object: !astropy.cosmology.Planck18
 cosmology: !astropy.cosmology.FlatLambdaCDM
   H0: 67.74
   Om0: 0.3075

--- a/skypy/pipeline/tests/test_config.py
+++ b/skypy/pipeline/tests/test_config.py
@@ -3,6 +3,7 @@ import pytest
 from skypy.pipeline import load_skypy_yaml
 from skypy.pipeline._items import Call
 from astropy import units
+from astropy.cosmology.core import Cosmology
 
 
 def test_load_skypy_yaml():
@@ -18,6 +19,8 @@ def test_load_skypy_yaml():
     assert isinstance(config['test_float'], float)
     assert isinstance(config['test_str'], str)
     assert isinstance(config['test_func'], Call)
+    assert isinstance(config['test_func_with_arg'], Call)
+    assert isinstance(config['test_object'], Cosmology)
     assert isinstance(config['cosmology'], Call)
     assert isinstance(config['tables']['test_table_1']['test_column_3'], Call)
 

--- a/skypy/pipeline/tests/test_config.py
+++ b/skypy/pipeline/tests/test_config.py
@@ -34,6 +34,11 @@ def test_load_skypy_yaml():
     with pytest.raises(ImportError):
         load_skypy_yaml(filename)
 
+    # Bad object
+    filename = get_pkg_data_filename('data/bad_object.yml')
+    with pytest.raises(ValueError):
+        load_skypy_yaml(filename)
+
 
 def test_empty_ref():
     filename = get_pkg_data_filename('data/test_empty_ref.yml')


### PR DESCRIPTION
## Description
This is a proposal for an extension to the config syntax that allows objects to be imported directly from external (sub)modules using the `!` tag and providing neither a list of args or a dict of kwargs. (N.B. to call a function without any arguments pass and empty list of args or an empty dict of kwargs). For example this enables:

```yaml
cosmo1: !astropy.cosmology.Planck18 # import the Planck18 object and bind to cosmo1
cosmo2: !astropy.cosmology.default_cosmology.get [] # call default_cosmology.get() and bind to cosmo2
```

Note that as a result of the design, it is no longer possible to call a function with a single argument using a scalar node; the argument must be put into a list:
```yaml
old_syntax: !len 'hello world!' # invalid
new_syntax: !len ['hello world!'] # correctly define an explicit list of args
```

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [x] Write unit tests
- [ ] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
