### PR TITLE
DOC: Add placeholder for ellipticity example

### DIFF
--- a/examples/galaxies/plot_ellipticity.py
+++ b/examples/galaxies/plot_ellipticity.py
@@ -1,0 +1,42 @@
+"""
+Galaxy Ellipticity Distributions
+================================
+
+This example demonstrate how to sample ellipticity distributions
+in SkyPy.
+
+"""
+
+
+# %%
+# 3D ellipticity istribution
+# --------------------------
+#
+# In Ryden 2004 [1]_, ...
+#
+# .. math::
+#
+#    \log_{10} (\bar{R}/{\rm kpc}) = -0.4aM + b,
+#
+# with :math:`a` and :math:`b` fitting constants. Likewise, late-type galaxies
+# follow Equation 15:
+#
+
+import numpy as np
+import matplotlib.pyplot as plt
+from skypy.galaxies.morphology import ryden04_ellipticity
+
+# %%
+# Validation against SDSS Data
+# ----------------------------
+
+# Plot here
+
+# %%
+# References
+# ----------
+#
+#
+# .. [1] Ryden, Barbara S., 2004, `The Astrophysical Journal, Volume 601, Issue 1, pp. 214-220`_
+#
+# .. _The Astrophysical Journal, Volume 601, Issue 1, pp. 214-220: https://arxiv.org/abs/astro-ph/0310097


### PR DESCRIPTION
## Description
This PR includes the validation plot for the 3D ellipticity model ([Ryden04](https://skypy.readthedocs.io/en/latest/api/skypy.galaxies.morphology.ryden04_ellipticity.html#skypy.galaxies.morphology.ryden04_ellipticity)) in the [examples](https://skypy.readthedocs.io/en/latest/examples/index.html) page.
It reproduces the distribution of axis ratio `𝑞_{am}` for exponential galaxies in the SDSS DR1 as done by @ntessore [here](https://ntessore.page/reproduce/sources/ryden_2004/index.html#index-0). 
Merging this PR closes #470.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [x] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [ ] Assign someone from the infrastructure team to review this pull request

## References
- [Ryden, Barbara S., 2004, The Astrophysical Journal, Volume 601, Issue 1, pp. 214-220.](https://arxiv.org/abs/astro-ph/0310097)