### PR TITLE
DOC: Inverse transform sampling accuracy warning

### DIFF
--- a/skypy/galaxies/redshift.py
+++ b/skypy/galaxies/redshift.py
@@ -216,12 +216,6 @@ def redshifts_from_comoving_density(redshift, density, sky_area, cosmology, nois
     If the `noise` parameter is set to true, the number of galaxies has Poisson
     noise. If `noise` is false, the expected number of galaxies is used.
 
-    .. warning::
-        The inverse cumulative distribution function is approximated from the
-        number density and comoving volume calculated at the given `redshift`
-        values. The user must choose suitable `redshift` values to satisfy
-        their desired numerical accuracy.
-
     Parameters
     ----------
     redshift : array_like
@@ -240,6 +234,13 @@ def redshifts_from_comoving_density(redshift, density, sky_area, cosmology, nois
     redshifts : array_like
         Sampled redshifts such that the comoving number density of galaxies
         corresponds to the input distribution.
+
+    Warnings
+    --------
+    The inverse cumulative distribution function is approximated from the
+    number density and comoving volume calculated at the given `redshift`
+    values. The user must choose suitable `redshift` values to satisfy their
+    desired numerical accuracy.
 
     '''
 

--- a/skypy/galaxies/redshift.py
+++ b/skypy/galaxies/redshift.py
@@ -216,6 +216,12 @@ def redshifts_from_comoving_density(redshift, density, sky_area, cosmology, nois
     If the `noise` parameter is set to true, the number of galaxies has Poisson
     noise. If `noise` is false, the expected number of galaxies is used.
 
+    .. warning::
+        The inverse cumulative distribution function is approximated from the
+        number density and comoving volume calculated at the given `redshift`
+        values. The user must choose suitable `redshift` values to satisfy
+        their desired numerical accuracy.
+
     Parameters
     ----------
     redshift : array_like

--- a/skypy/utils/random.py
+++ b/skypy/utils/random.py
@@ -21,12 +21,6 @@ import numpy as np
 def schechter(alpha, x_min, x_max, resolution=100, size=None, scale=1.):
     """Sample from the Schechter function.
 
-    .. warning::
-        The inverse cumulative distribution function is approximated from the
-        Schechter function evaluated on a logarithmically-spaced grid. The user
-        must choose the `resolution` of this grid to satisfy their desired
-        numerical accuracy.
-
     Parameters
     ----------
     alpha : float or int
@@ -46,6 +40,13 @@ def schechter(alpha, x_min, x_max, resolution=100, size=None, scale=1.):
     -------
     x_sample : array_like
         Samples drawn from the Schechter function.
+
+    Warnings
+    --------
+    The inverse cumulative distribution function is approximated from the
+    Schechter function evaluated on a logarithmically-spaced grid. The user
+    must choose the `resolution` of this grid to satisfy their desired
+    numerical accuracy.
 
     References
     ----------

--- a/skypy/utils/random.py
+++ b/skypy/utils/random.py
@@ -21,6 +21,12 @@ import numpy as np
 def schechter(alpha, x_min, x_max, resolution=100, size=None, scale=1.):
     """Sample from the Schechter function.
 
+    .. warning::
+        The inverse cumulative distribution function is approximated from the
+        Schechter function evaluated on a logarithmically-spaced grid. The user
+        must choose the `resolution` of this grid to satisfy their desired
+        numerical accuracy.
+
     Parameters
     ----------
     alpha : float or int


### PR DESCRIPTION
## Description
Add warnings to the docstrings for `schechter` and `redshifts_from_comoving_density` highlighting that the user must choose the `resolution` and `redshift` parameters respectively so as to satisfy their own numerical accuracy requirements.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [x] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
