### PR TITLE
ENH: Rename keyword argument noise to shot_noise

### DIFF
--- a/skypy/galaxies/_schechter.py
+++ b/skypy/galaxies/_schechter.py
@@ -14,7 +14,7 @@ __all__ = [
 
 
 @units.quantity_input(sky_area=units.sr)
-def schechter_lf(redshift, M_star, phi_star, alpha, m_lim, sky_area, cosmology, noise=True):
+def schechter_lf(redshift, M_star, phi_star, alpha, m_lim, sky_area, cosmology, shot_noise=True):
     r'''Sample redshifts and magnitudes from a Schechter luminosity function.
 
     Sample the redshifts and magnitudes of galaxies following a Schechter
@@ -42,8 +42,9 @@ def schechter_lf(redshift, M_star, phi_star, alpha, m_lim, sky_area, cosmology, 
         Sky area over which galaxies are sampled. Must be in units of solid angle.
     cosmology : Cosmology
         Cosmology object to convert apparent to absolute magnitudes.
-    noise : bool, optional
-        Poisson-sample the number of galaxies. Default is `True`.
+    shot_noise : bool, optional
+        Wether to Poisson-sample the number of galaxies, or else use the mean
+        number. Default is `True`.
 
     Notes
     -----
@@ -61,7 +62,7 @@ def schechter_lf(redshift, M_star, phi_star, alpha, m_lim, sky_area, cosmology, 
     '''
 
     # sample galaxy redshifts
-    z = schechter_lf_redshift(redshift, M_star, phi_star, alpha, m_lim, sky_area, cosmology, noise)
+    z = schechter_lf_redshift(redshift, M_star, phi_star, alpha, m_lim, sky_area, cosmology, shot_noise)
 
     # if a function is NOT given for M_star, phi_star, alpha, interpolate to z
     if not callable(M_star) and np.ndim(M_star) > 0:


### PR DESCRIPTION
## Description
In the function `schechter_lf` rename the keyword argument `noise` to `shot_noise`. Breaking API change to be considered for 1.0 release.  Requires deprecation warnings before merging. Resolves #478 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
