### PR TITLE
MAINT: Set astropy latest supported version to 4.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ packages = find:
 python_requires = >=3.6
 setup_requires = setuptools_scm
 install_requires =
-    astropy>=4
+    astropy>=4,<4.3
     networkx
     numpy
     scipy


### PR DESCRIPTION
## Description
As discussed in #482 there is a conflict between speclite 0.13 (latest) and astropy 4.3.x. It is therefore necessary to make astropy 4.2.x our latest supported version until a fix to speclite is released.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
