### PR TITLE
BUG: Change invalid ecsv datatype from int to uint16

### DIFF
--- a/examples/galaxies/sdss_dered_10deg2.ecsv
+++ b/examples/galaxies/sdss_dered_10deg2.ecsv
@@ -9,15 +9,15 @@
 # - name: magnitude
 #   datatype: float32
 # - name: dered_u
-#   datatype: int
+#   datatype: uint16
 # - name: dered_g
-#   datatype: int
+#   datatype: uint16
 # - name: dered_r
-#   datatype: int
+#   datatype: uint16
 # - name: dered_i
-#   datatype: int
+#   datatype: uint16
 # - name: dered_z
-#   datatype: int
+#   datatype: uint16
 magnitude dered_u dered_g dered_r dered_i dered_z
 15.0 5 6 5 9 9
 15.1 4 5 11 8 17


### PR DESCRIPTION
## Description
In the ecsv file [`examples/galaxies/sdss_dered_10deg2.ecsv`](https://github.com/skypyproject/skypy/blob/main/examples/galaxies/sdss_dered_10deg2.ecsv) change the invalid datatype `int` to `uint16`. Resolves #484 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
