### PR TITLE
BLD: Set astropy latest supported version to 4.3 and speclite minversion to 0.14

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,14 +31,14 @@ console_scripts =
 test =
     pytest-astropy
     pytest-rerunfailures
-    speclite>=0.11
+    speclite>=0.14
 all =
     h5py
-    speclite>=0.11
+    speclite>=0.14
 docs =
     sphinx-astropy
     matplotlib
-    speclite>=0.11
+    speclite>=0.14
 
 [options.package_data]
 skypy = data/*,data/*/*,*/tests/data/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ packages = find:
 python_requires = >=3.6
 setup_requires = setuptools_scm
 install_requires =
-    astropy>=4,<4.3
+    astropy>=4
     networkx
     numpy
     scipy

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{36,37,38,39}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
     py{36,37,38,39}-test-numpy{116,117,118,119,120}
     py{36,37,38,39}-test-scipy{12,13,14,15,16}
-    py{36,37,38,39}-test-astropy{40,41,42}
+    py{36,37,38,39}-test-astropy{40,41,42,43}
     build_docs
     linkcheck
     codestyle
@@ -51,6 +51,7 @@ description =
     astropy40: with astropy 4.0.*
     astropy41: with astropy 4.1.*
     astropy42: with astropy 4.2.*
+    astropy43: with astropy 4.3.*
 
 # The following provides some specific pinnings for key packages
 deps =
@@ -70,12 +71,13 @@ deps =
     astropy40: astropy==4.0.*
     astropy41: astropy==4.1.*
     astropy42: astropy==4.2.*
+    astropy43: astropy==4.3.*
 
     dev: :NIGHTLY:numpy
     dev: :NIGHTLY:scipy
     dev: git+https://github.com/astropy/astropy.git#egg=astropy
 
-    latest: astropy==4.2.*
+    latest: astropy==4.3.*
     latest: numpy==1.20.*
     latest: scipy==1.6.*
 


### PR DESCRIPTION
## Description
speclite 0.14 will contain a fix that allows us to support astropy 4.3.x. Resolves #482 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
