### PR TITLE
TST: Use tmp_path fixture for temporary files in unit tests

### DIFF
--- a/skypy/pipeline/tests/test_pipeline.py
+++ b/skypy/pipeline/tests/test_pipeline.py
@@ -21,7 +21,7 @@ else:
     HAS_H5PY = True
 
 
-def test_pipeline():
+def test_pipeline(tmp_path):
 
     # Evaluate and store the default astropy cosmology.
     config = {'test_cosmology': Call(default_cosmology.get)}
@@ -44,7 +44,7 @@ def test_pipeline():
 
     pipeline = Pipeline(config)
     pipeline.execute()
-    output_filename = 'output.fits'
+    output_filename = str(tmp_path / 'output.fits')
     pipeline.write(output_filename)
     assert len(pipeline['test_table']) == size
     assert np.all(pipeline['test_table.column1'] < pipeline['test_table.column2'])
@@ -251,7 +251,7 @@ def test_column_quantity():
 
 
 @pytest.mark.skipif(not HAS_H5PY, reason='Requires h5py')
-def test_hdf5():
+def test_hdf5(tmp_path):
     size = 100
     string = size*'a'
     config = {'tables': {
@@ -264,16 +264,7 @@ def test_hdf5():
 
     pipeline = Pipeline(config)
     pipeline.execute()
-    pipeline.write('output.hdf5')
-    hdf_table = read_table_hdf5('output.hdf5', 'tables/test_table', character_as_bytes=False)
+    output_filename = str(tmp_path / 'output.hdf5')
+    pipeline.write(output_filename)
+    hdf_table = read_table_hdf5(output_filename, 'tables/test_table', character_as_bytes=False)
     assert np.all(hdf_table == pipeline['test_table'])
-
-
-def teardown_module(module):
-
-    # Remove fits file generated in test_pipeline
-    os.remove('output.fits')
-
-    # Remove hdf5 file generated in test_hdf5
-    if HAS_H5PY:
-        os.remove('output.hdf5')

--- a/skypy/pipeline/tests/test_pipeline.py
+++ b/skypy/pipeline/tests/test_pipeline.py
@@ -8,7 +8,6 @@ from astropy.units import Quantity
 from astropy.utils.data import get_pkg_data_filename
 import networkx
 import numpy as np
-import os
 import pytest
 from skypy.pipeline import Pipeline
 from skypy.pipeline._items import Call, Ref

--- a/skypy/pipeline/tests/test_skypy.py
+++ b/skypy/pipeline/tests/test_skypy.py
@@ -93,7 +93,7 @@ def test_logging(capsys, tmp_path):
     assert(f"[INFO] skypy: Writing {output_filename}" in err)
 
     # Check error for existing output file is in the log
-    assert(f"[ERROR] skypy: File '{output_filename}' already exists." in err)
+    assert(f"[ERROR] skypy: File {output_filename!r} already exists." in err)
 
     # Run again with decreased verbosity and check the log is empty
     with pytest.raises(SystemExit):

--- a/skypy/pipeline/tests/test_skypy.py
+++ b/skypy/pipeline/tests/test_skypy.py
@@ -10,7 +10,7 @@ from skypy.pipeline._items import Call
 from skypy.pipeline.scripts import skypy
 
 
-def test_skypy():
+def test_skypy(tmp_path):
 
     # No arguments
     with pytest.raises(SystemExit) as e:
@@ -36,36 +36,39 @@ def test_skypy():
     assert e.value.code == 2
 
     # Process empty config file
-    filename = get_pkg_data_filename('data/empty_config.yml')
-    assert skypy.main([filename, 'empty.fits']) == 0
+    config_filename = get_pkg_data_filename('data/empty_config.yml')
+    output_filename = str(tmp_path / 'empty.fits')
+    assert skypy.main([config_filename, output_filename]) == 0
 
     # Process test config file
-    filename = get_pkg_data_filename('data/test_config.yml')
-    assert skypy.main([filename, 'test.fits']) == 0
+    config_filename = get_pkg_data_filename('data/test_config.yml')
+    output_filename = str(tmp_path / 'test.fits')
+    assert skypy.main([config_filename, output_filename]) == 0
 
     # Invalid file format
+    output_filename = str(tmp_path / 'test.invalid')
     with pytest.raises(SystemExit) as e:
-        skypy.main([filename, 'test.invalid'])
+        skypy.main([config_filename, output_filename])
     assert e.value.code == 2
 
 
-def test_logging(capsys):
+def test_logging(capsys, tmp_path):
 
     # Run skypy with default verbosity and check log is empty
-    filename = get_pkg_data_filename('data/test_config.yml')
-    output_file = 'logging.fits'
-    skypy.main([filename, output_file])
+    config_filename = get_pkg_data_filename('data/test_config.yml')
+    output_filename = str(tmp_path / 'logging.fits')
+    skypy.main([config_filename, output_filename])
     out, err = capsys.readouterr()
     assert(not err)
 
     # Run again with increased verbosity and capture log. Force an exception by
     # not using the "--overwrite" flag when the output file already exists.
     with pytest.raises(SystemExit):
-        skypy.main([filename, output_file, '--verbose'])
+        skypy.main([config_filename, output_filename, '--verbose'])
     out, err = capsys.readouterr()
 
     # Determine all DAG jobs and function calls from config
-    config = load_skypy_yaml(filename)
+    config = load_skypy_yaml(config_filename)
     cosmology = config.pop('cosmology', None)
     tables = config.pop('tables', {})
     config.update({k: v.pop('.init', Call(Table)) for k, v in tables.items()})
@@ -88,21 +91,13 @@ def test_logging(capsys):
         assert("[INFO] skypy.pipeline: Setting cosmology" in err)
 
     # Check writing output file is in the log
-    assert(f"[INFO] skypy: Writing {output_file}" in err)
+    assert(f"[INFO] skypy: Writing {output_filename}" in err)
 
     # Check error for existing output file is in the log
-    assert(f"[ERROR] skypy: File '{output_file}' already exists." in err)
+    assert(f"[ERROR] skypy: File '{output_filename}' already exists." in err)
 
     # Run again with decreased verbosity and check the log is empty
     with pytest.raises(SystemExit):
-        skypy.main([filename, output_file, '-qq'])
+        skypy.main([config_filename, output_filename, '-qq'])
     out, err = capsys.readouterr()
     assert(not err)
-
-
-def teardown_module(module):
-
-    # Remove fits file generated in test_skypy
-    os.remove('empty.fits')
-    os.remove('logging.fits')
-    os.remove('test.fits')

--- a/skypy/pipeline/tests/test_skypy.py
+++ b/skypy/pipeline/tests/test_skypy.py
@@ -2,7 +2,6 @@ from astropy.table import Table
 from astropy.utils.data import get_pkg_data_filename
 from contextlib import redirect_stdout
 from io import StringIO
-import os
 import pytest
 from skypy import __version__ as skypy_version
 from skypy.pipeline import load_skypy_yaml


### PR DESCRIPTION
## Description
Use pytest `tmp_path` fixture in unit tests. Creates a temporary directory where temporary files can be written and handles cleanup automatically. Resolves #466 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
