### PR TITLE
DEV: Enable pip to install pre-releases in the tox dev environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -92,6 +92,10 @@ extras =
     test
     all: all
 
+# Enable pip to install pre-releases in the dev environment
+pip_pre =
+    dev: True
+
 commands =
     pip freeze
     !cov: pytest --pyargs skypy {toxinidir}/docs {posargs}


### PR DESCRIPTION
## Description
Enable pip to install pre-releases in the tox dev environments. Fixes #490 since the scipy-wheels-server only hosts pre-releases and so there are no *releases* of numpy satisfying scipys dependency on `numpy>=1.17.3`. Setting  `pip_pre=True` allows pip to install the `numpy==1.22.0.dev` *pre-release* resolving the dependency conflict. See compatibility workflow logs on the rrjbca/skypy fork e.g. [HERE](https://github.com/rrjbca/skypy/runs/3531344737?check_suite_focus=true) demonstrating successful execution of the compatibility workflow in the `py39-test-dev` environment. 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
