### PR TITLE
DEV: setuptools==58.0.0

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,7 @@ sphinx:
 python:
   version: 3.7
   install:
+    - requirements: docs/requirements.txt
     - method: pip
       path: .
       extra_requirements:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+setuptools==58.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 
-requires = ["setuptools<=58.0.1",
+requires = ["setuptools",
             "setuptools_scm",
             "wheel"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 
-requires = ["setuptools",
+requires = ["setuptools<=58.0.1",
             "setuptools_scm",
             "wheel"]
 


### PR DESCRIPTION
## Description
speclite 0.13 is incompatible with the recent setuptools 58.0.2 release. Fix the version of setuptools used to `setuptools<58.0.2` until the dependency conflict is resolved. Resolves #492 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
