### PR TITLE
REV: restore setuptools to latest version on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,6 @@ sphinx:
 python:
   version: 3.7
   install:
-    - requirements: docs/requirements.txt
     - method: pip
       path: .
       extra_requirements:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,0 @@
-setuptools==58.0.0


### PR DESCRIPTION
This reverts PR #493. To be merged after a new speclite release fixing the incompatibility with setuptools>=58.0.2

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
