### PR TITLE
DEV: pyparsing<3.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ docs =
     sphinx-astropy
     matplotlib
     speclite>=0.14
+    pyparsing<3.0.0
 
 [options.package_data]
 skypy = data/*,data/*/*,*/tests/data/*


### PR DESCRIPTION
## Description
matplotlib 3.4.3 is incompatible with the recent pyparsing 3.x releases. Fix the version of pyparsing used to pyparsing<3.0.0 until the dependency conflict is resolved. Resolves #499 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
