### PR TITLE
REV: restore pyparsing to latest version for doc builds

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ docs =
     sphinx-astropy
     matplotlib
     speclite>=0.14
-    pyparsing<3.0.0
 
 [options.package_data]
 skypy = data/*,data/*/*,*/tests/data/*


### PR DESCRIPTION
## Description
Reverts #500. To be merged after a new matplotlib release fixing the incompatibility with pyparsing 3.x

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
