### PR TITLE
BLD: Set astropy latest supported version to 5.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{36,37,38,39}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
     py{36,37,38,39}-test-numpy{116,117,118,119,120,121}
     py{36,37,38,39}-test-scipy{12,13,14,15,16,17}
-    py{36,37,38,39}-test-astropy{40,41,42,43}
+    py{36,37,38,39}-test-astropy{40,41,42,43,50}
     build_docs
     linkcheck
     codestyle
@@ -54,6 +54,7 @@ description =
     astropy41: with astropy 4.1.*
     astropy42: with astropy 4.2.*
     astropy43: with astropy 4.3.*
+    astropy50: with astropy 5.0.*
 
 # The following provides some specific pinnings for key packages
 deps =
@@ -76,12 +77,13 @@ deps =
     astropy41: astropy==4.1.*
     astropy42: astropy==4.2.*
     astropy43: astropy==4.3.*
+    astropy50: astropy==5.0.*
 
     dev: :NIGHTLY:numpy
     dev: :NIGHTLY:scipy
     dev: git+https://github.com/astropy/astropy.git#egg=astropy
 
-    latest: astropy==4.3.*
+    latest: astropy==5.0.*
     latest: numpy==1.21.*
     latest: scipy==1.7.*
 


### PR DESCRIPTION
## Description
Set astropy latest supported version to 5.0

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
