### PR TITLE
BLD: Set numpy latest supported version to 1.22

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{36,37,38,39}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
-    py{36,37,38,39}-test-numpy{116,117,118,119,120,121}
+    py{36,37,38,39}-test-numpy{116,117,118,119,120,121,122}
     py{36,37,38,39}-test-scipy{12,13,14,15,16,17}
     py{36,37,38,39}-test-astropy{40,41,42,43,50}
     build_docs
@@ -44,6 +44,7 @@ description =
     numpy119: with numpy 1.19.*
     numpy120: with numpy 1.20.*
     numpy121: with numpy 1.21.*
+    numpy122: with numpy 1.22.*
     scipy12: with scipy 1.2.*
     scipy13: with scipy 1.3.*
     scipy14: with scipy 1.4.*
@@ -65,6 +66,7 @@ deps =
     numpy119: numpy==1.19.*
     numpy120: numpy==1.20.*
     numpy121: numpy==1.21.*
+    numpy122: numpy==1.22.*
 
     scipy12: scipy==1.2.*
     scipy13: scipy==1.3.*
@@ -84,7 +86,7 @@ deps =
     dev: git+https://github.com/astropy/astropy.git#egg=astropy
 
     latest: astropy==5.0.*
-    latest: numpy==1.21.*
+    latest: numpy==1.22.*
     latest: scipy==1.7.*
 
     oldest: astropy==4.0.*


### PR DESCRIPTION
## Description
Set numpy latest supported version to 1.22

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
