### PR TITLE
BLD: Set python oldest supported version to 3.7

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,8 +25,8 @@ jobs:
 
           - name: oldest supported versions
             os: ubuntu-latest
-            python: 3.6
-            toxenv: py36-test-oldest
+            python: 3.7
+            toxenv: py37-test-oldest
 
           - name: macOS latest supported
             os: macos-latest

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -129,7 +129,7 @@ Before your pull request can be merged into the codebase, it will be reviewed by
 General Guidelines
 ^^^^^^^^^^^^^^^^^^
 
-- SkyPy is compatible with Python>=3.6 (see `setup.cfg <https://github.com/skypyproject/skypy/blob/main/setup.cfg>`_). SkyPy *does not* support backwards compatibility with Python 2.x; `six`, `__future__` and `2to3` should not be used.
+- SkyPy is compatible with Python>=3.7 (see `setup.cfg <https://github.com/skypyproject/skypy/blob/main/setup.cfg>`_). SkyPy *does not* support backwards compatibility with Python 2.x; `six`, `__future__` and `2to3` should not be used.
 - All contributions should follow the `PEP8 Style Guide for Python Code <https://www.python.org/dev/peps/pep-0008/>`_. We recommend using `flake8 <https://flake8.pycqa.org/>`__ to check your code for PEP8 compliance.
 - Importing SkyPy should only depend on having `NumPy <https://www.numpy.org>`_, `SciPy <https://www.scipy.org/>`_ and `Astropy <https://www.astropy.org/>`__ installed.
 - Code is grouped into submodules based on broad science areas e.g. `galaxies <https://skypy.readthedocs.io/en/stable/galaxies.html>`_. There is also a `utils <https://skypy.readthedocs.io/en/stable/utils/index.html>`_ submodule for general utility functions.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -40,7 +40,7 @@ can be installed directly from GitHub using a recent version of pip:
 Dependencies
 ------------
 
-SkyPy is compatble with Python versions 3.6 or later on Ubuntu, macOS and
+SkyPy is compatble with Python versions 3.7 or later on Ubuntu, macOS and
 Windows operating systems. It has the following core dependencies:
 
 - `astropy <https://www.astropy.org/>`__

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ github_project = skypyproject/skypy
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     astropy>=4

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
-    py{36,37,38,39,310}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
-    py{36,37,38,39,310}-test-numpy{116,117,118,119,120,121,122}
-    py{36,37,38,39,310}-test-scipy{12,13,14,15,16,17}
-    py{36,37,38,39,310}-test-astropy{40,41,42,43,50}
+    py{37,38,39,310}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
+    py{37,38,39,310}-test-numpy{116,117,118,119,120,121,122}
+    py{37,38,39,310}-test-scipy{12,13,14,15,16,17}
+    py{37,38,39,310}-test-astropy{40,41,42,43,50}
     build_docs
     linkcheck
     codestyle


### PR DESCRIPTION
## Description
Python 3.6 is end-of-life and future releases should not support it. This PR sets the oldest supported version of python to 3.7

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [x] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
