### PR TITLE
DOC: Fix code of conduct link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ All communication relating to The SkyPy Project must meet the standards set out
 in the `Code of Conduct`_.
 
 .. _Contributor Guidelines: https://skypy.readthedocs.io/en/latest/developer/contributing.html
-.. _Code of Conduct: https://skypy.readthedocs.io/en/stable/project/CODE_OF_CONDUCT.html
+.. _Code of Conduct: https://skypy.readthedocs.io/en/stable/project/code_of_conduct.html
 
 .. |PyPI| image:: https://img.shields.io/pypi/v/skypy?label=PyPI&logo=pypi
     :target: https://pypi.python.org/pypi/skypy


### PR DESCRIPTION
## Description
The link to the code of conduct was broken in the readme.
## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
