### PR TITLE
ENH: galaxy-quenching model

### DIFF
--- a/docs/galaxies.rst
+++ b/docs/galaxies.rst
@@ -89,6 +89,7 @@ The following models are found in the `skypy.galaxies.stellar_mass` package.
   :nosignatures:
 
   schechter_smf_mass
+  schechter_smf_parameters
 
 
 Reference/API

--- a/skypy/galaxies/stellar_mass.py
+++ b/skypy/galaxies/stellar_mass.py
@@ -8,6 +8,7 @@ from ..utils.random import schechter
 
 __all__ = [
     'schechter_smf_mass',
+    'schechter_smf_parameters',
 ]
 
 
@@ -74,3 +75,54 @@ def schechter_smf_mass(redshift, alpha, m_star, m_min, m_max, size=None,
     m = schechter(alpha, x_min, x_max, resolution, size=size, scale=m_star)
 
     return m
+
+
+def schechter_smf_parameters(active_parameters, fsatellite, fenvironment):
+    r'''Schechter parameters.
+    This function returns the Schechter mass function parameters
+    for active galaxies (centrals and satellites)
+    and passive galaxies (mass- and satellite-quenched)
+    based on equation (15) in de la Bella et al. 2021 [1]_.
+
+    Parameters
+    ----------
+    active_parameters: tuple
+        Schechter mass function parameters for the entire active
+        sample of galaxies: :math:`(\phi_b, \alpha_b, m_{*})`.
+
+    fsatellite: float, (n, ) array_like
+        Fraction of active satellite galaxies between 0 and 1.
+        It could be a float or an array, depending on the model you choose.
+
+    fenvironment: float
+        Fraction of satellite-quenched galaxies between 0 and 1.
+
+
+    Returns
+    -------
+    parameters: dic
+        It returns a  dictionary with the parameters of the
+        Schechter mass function. The dictionary keywords:
+        `centrals`, `satellites`, `mass_quenched` and
+        `satellite_quenched`. The values correspond to a
+        tuple :math:`(\phi, \alpha, m_{*})`.
+
+    References
+    ----------
+    .. [1] de la Bella et al. 2021, Quenching and Galaxy Demographics,
+           arXiv 2112.11110.
+
+    '''
+    phi, alpha, mstar = active_parameters
+
+    sum_phics = (1 - fsatellite) * (1 - np.log(1 - fsatellite))
+    phic = (1 - fsatellite) * phi / sum_phics
+    phis = phic * np.log(1 / (1 - fsatellite))
+
+    centrals = (phic, alpha, mstar)
+    satellites = (phis, alpha, mstar)
+    mass_quenched = (phi, alpha + 1, mstar)
+    satellite_quenched = (- np.log(1 - fenvironment) * phis, alpha, mstar)
+
+    return {'centrals': centrals, 'satellites': satellites,
+            'mass_quenched': mass_quenched, 'satellite_quenched': satellite_quenched}

--- a/skypy/halo/quenching.py
+++ b/skypy/halo/quenching.py
@@ -1,0 +1,106 @@
+"""Galaxy quenching.
+
+This module implements models for environment and mass
+quenching by dark matter halos.
+"""
+
+import numpy as np
+from scipy import special
+
+__all__ = [
+    'environment_quenched',
+    'mass_quenched',
+    ]
+
+
+def environment_quenched(nh, probability):
+    r'''Environment quenching function.
+    This function implements the model proposed by A.Amara where the
+    probability of a subhalo being quenched is a fixed
+    probability. The model is inspired on [1]_ and [2]_.
+
+    Parameters
+    ----------
+    nh: integer
+        Number of subhalos.
+    probability: float
+        Quenching probability.
+
+    Returns
+    -------
+    quenched: (nh,) array_like,  boolean
+        Boolean array indicating which subhalo's host galaxies are
+        (satellite) environment-quenched.
+
+    Examples
+    ---------
+
+    This example shows how many subhalos are environtment quenched (True)
+    and how many survive (False) from a list of 1000 halos:
+
+    >>> import numpy as np
+    >>> from skypy.halo.quenching import environment_quenched
+    >>> from collections import Counter
+    >>> quenched = environment_quenched(1000, 0.5)
+    >>> Counter(quenched)
+    Counter({...})
+
+    References
+    ----------
+    .. [1] Peng et al. 2010, doi 10.1088/0004-637X/721/1/193.
+    .. [2] Birrer et al. 2014, arXiv 1401.3162.
+
+    '''
+
+    return np.random.uniform(size=nh) < probability
+
+
+def mass_quenched(halo_mass, offset, width):
+    r'''Mass quenching function.
+    This function implements the model proposed by A.Amara where the
+    probability of a halo being quenched is related to the error function
+    of the logarithm of the halo's mass standardised by an offset and width
+    parameter.  The model is inspired on [1]_ and [2]_.
+
+    Parameters
+    ----------
+    halo_mass: (nh,) array_like
+        Array of halo masses in units of solar mass, :math:`M_{sun}`.
+    offset: float
+        Halo mass in :math:`M_{sun}` at which quenching probability is 50%.
+    width: float
+        Width of the error function.
+
+    Returns
+    -------
+    quenched: (nh,) array_like, boolean
+        Boolean array indicating which halo's host galaxies are mass-quenched.
+
+    Examples
+    ---------
+
+    This example shows how many halos are mass quenched (True)
+    and how many survive (False) from a list of 1000 halos:
+
+    >>> import numpy as np
+    >>> from astropy import units
+    >>> from skypy.halo.quenching import mass_quenched
+    >>> from collections import Counter
+    >>> offset, width = 1.0e12, 0.5
+    >>> halo_mass = np.random.lognormal(mean=np.log(offset), sigma=width,
+    ...                                 size=1000)
+    >>> quenched = mass_quenched(halo_mass, offset, width)
+    >>> Counter(quenched)
+    Counter({...})
+
+    References
+    ----------
+    .. [1] Peng et al. 2010, doi 10.1088/0004-637X/721/1/193.
+    .. [2] Birrer et al. 2014, arXiv 1401.3162.
+
+    '''
+
+    standardised_mass = np.log10(halo_mass / offset) / width
+    probability = 0.5 * (1.0 + special.erf(standardised_mass/np.sqrt(2)))
+    nh = len(halo_mass)
+    return np.random.uniform(size=nh) < probability

--- a/skypy/halo/tests/test_quenching.py
+++ b/skypy/halo/tests/test_quenching.py
@@ -1,0 +1,30 @@
+import numpy as np
+from scipy import stats
+from collections import Counter
+
+from skypy.halo.quenching import environment_quenched, mass_quenched
+
+
+def test_environment_quenched():
+    # Test the quenching process follows a binomial distribution
+    n, p = 1000, 0.7
+    quenched = environment_quenched(n, p)
+    number_quenched = Counter(quenched)[True]
+
+    p_value = stats.binom_test(number_quenched, n=n, p=p,
+                               alternative='two-sided')
+    assert p_value > 0.05
+
+
+def test_mass_quenched():
+    # Test the quenching process follows a binomial distribution if the
+    # logarithmic halo masses are symmetrical about the offset
+    n = 1000
+    offset, width = 1.0e12, 0.5
+    halo_mass = 10 ** np.random.uniform(11, 13, n)
+    quenched = mass_quenched(halo_mass, offset, width)
+    number_quenched = Counter(quenched)[True]
+
+    p_value = stats.binom_test(number_quenched, n=n, p=0.5,
+                               alternative='two-sided')
+    assert p_value > 0.05


### PR DESCRIPTION
## Description
This PR adds a feature where we can obtain the Schechter parameters for active galaxies (centrals and satellites) and passive galaxies (mass- and satellite-quenched) based on equation (15) in de la Bella et al. 2021. Merging this PR coses #513 .

## Checklist
- [ ] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [ ] Assign someone from the infrastructure team to review this pull request
