### PR TITLE
BUG: `schechter_smf` callable input and docs

### DIFF
--- a/skypy/galaxies/__init__.py
+++ b/skypy/galaxies/__init__.py
@@ -5,6 +5,7 @@ populations.
 
 __all__ = [
     'schechter_lf',
+    'schechter_smf',
 ]
 
 from . import luminosity  # noqa F401,F403

--- a/skypy/galaxies/stellar_mass.py
+++ b/skypy/galaxies/stellar_mass.py
@@ -4,6 +4,7 @@
 import numpy as np
 
 from ..utils.random import schechter
+from ..utils import dependent_argument
 
 
 __all__ = [
@@ -11,6 +12,8 @@ __all__ = [
 ]
 
 
+@dependent_argument('m_star', 'redshift')
+@dependent_argument('alpha', 'redshift')
 def schechter_smf_mass(redshift, alpha, m_star, m_min, m_max, size=None,
                        resolution=1000):
     r""" Stellar masses following the Schechter mass function [1]_.
@@ -19,9 +22,9 @@ def schechter_smf_mass(redshift, alpha, m_star, m_min, m_max, size=None,
     ----------
     redshift : array_like
         Galaxy redshifts for which to sample magnitudes.
-    alpha : float
+    alpha : float or function
         The alpha parameter in the Schechter stellar mass function.
-    m_star : (nm,) array-like
+    m_star : (nm,) array-like or function
         Characteristic stellar mass m_*.
     size: int, optional
          Output shape of stellar mass samples. If size is None and m_star

--- a/skypy/galaxies/stellar_mass.py
+++ b/skypy/galaxies/stellar_mass.py
@@ -23,7 +23,8 @@ def schechter_smf_mass(redshift, alpha, m_star, m_min, m_max, size=None,
     redshift : array_like
         Galaxy redshifts for which to sample magnitudes.
     alpha : float or function
-        The alpha parameter in the Schechter stellar mass function.
+        The alpha parameter in the Schechter stellar mass function. If function,
+        it must return a scalar value.
     m_star : (nm,) array-like or function
         Characteristic stellar mass m_*.
     size: int, optional


### PR DESCRIPTION
## Description
This PR enables `alpha` and `m_star` in `schechter_smf` being functions. Before it was prevented by the `schechter_smf_mass` function. To resolve I added a set of decorators to `schechter_smf_mass`. Closes #523.

Furthermore, I included `schechter_smf` in the docs where they weren't included before. Closes #522.  
## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
