### PR TITLE
Fix astropy default_cosmology in power spectrum documentation plot

### DIFF
--- a/docs/power_spectrum/examples/power_spectrum.yml
+++ b/docs/power_spectrum/examples/power_spectrum.yml
@@ -1,4 +1,4 @@
-cosmology: !astropy.cosmology.default_cosmology.get
+cosmology: !astropy.cosmology.default_cosmology.get []
 wavenumber: !numpy.logspace [-3, 1, 100]
 eisenstein_hu_wiggle: !skypy.power_spectrum.eisenstein_hu
   wavenumber: $wavenumber


### PR DESCRIPTION
## Description
Update the plot in the power spectrum documentation to match the new function call API. Note this still fails as there is an independent issue with the halofit functions

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
