### PR TITLE
Add __name__ to Halofit partial models for logging

### DIFF
--- a/skypy/power_spectrum/_halofit.py
+++ b/skypy/power_spectrum/_halofit.py
@@ -201,6 +201,14 @@ def halofit(wavenumber, redshift, linear_power_spectrum,
     return pknl.reshape(return_shape)
 
 
+# Smith et. al. 2003  model
 halofit_smith = partial(halofit, parameters=_smith_parameters)
+halofit_smith.__name__ = "halofit_smith"
+
+# Takahashi et al. 2012 model
 halofit_takahashi = partial(halofit, parameters=_takahashi_parameters)
+halofit_takahashi.__name__ = "halofit_takahashi"
+
+# Bird et al. 2012 model
 halofit_bird = partial(halofit, parameters=_bird_parameters)
+halofit_bird.__name__ = "halofit_bird"


### PR DESCRIPTION
## Description
Add __name__ to halofit partial models (halofit_smith, halofit_takahashi, halofit_bird) as this is required for pipeline logging. Partial fix to documentation build error in the power spectrum example plot.

~N.b. the readthedocs build error `AttributeError: 'function' object has no attribute 'Om0'` is a separate issue addressed by #527. This PR should be merged after that one.~

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
