### PR TITLE
TST: assert photometric error is numerically close to the analytic value

### DIFF
--- a/skypy/utils/tests/test_photometry.py
+++ b/skypy/utils/tests/test_photometry.py
@@ -200,7 +200,7 @@ def test_magnitude_error_rykoff():
     b = 2
     a = np.log(10) - 1.5 * b
     error = magnitude_error_rykoff(magnitude, magnitude_limit, magnitude_zp, a, b)
-    assert error == 2.5 / np.log(10) * np.sqrt(1 / 1000)
+    assert np.isclose(error, 0.25 / np.log(10) / np.sqrt(10))
 
     # test that error limit is returned if error is larger than error_limit
     # The following set-up would give a value larger than 10


### PR DESCRIPTION
## Description

The compatibility workflow is currently failing, see [HERE](https://github.com/skypyproject/skypy/runs/6438716098?check_suite_focus=true#step:6:116)

The development version of numpy appears to cause a small numerical change in the calculation of the Rykoff photometric error. This causes the unit test to fail because it asserts that the calculated error is exactly equal to the analytic value. This PR changes the test to assert that the calculated error is numerically close to the analytic value.

Compatibility tests are shown to work with this fix [HERE](https://github.com/rrjbca/skypy/actions/runs/2357233927)

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
