### PR TITLE
TST: Drop deprecated astropy.tests.helper.raises

### DIFF
--- a/skypy/utils/tests/test_special.py
+++ b/skypy/utils/tests/test_special.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numpy.testing as npt
 from astropy.utils.data import get_pkg_data_filename
-from astropy.tests.helper import raises
+import pytest
 
 from skypy.utils.special import gammaincc
 
@@ -80,13 +80,13 @@ def test_gammaincc_precision():
     npt.assert_allclose(g, v, rtol=1e-10, atol=0, err_msg='\n'.join(lines))
 
 
-@raises(ValueError)
 def test_gammaincc_neg_x_scalar():
     # negative x raises an exception
-    gammaincc(0.5, -1.0)
+    with pytest.raises(ValueError):
+        gammaincc(0.5, -1.0)
 
 
-@raises(ValueError)
 def test_gammaincc_neg_x_array():
     # negative x in array raises an exception
-    gammaincc(0.5, [3.0, 2.0, 1.0, 0.0, -1.0])
+    with pytest.raises(ValueError):
+        gammaincc(0.5, [3.0, 2.0, 1.0, 0.0, -1.0])


### PR DESCRIPTION
## Description
The latest astropy development version has deprecated `astropy.tests.helper.raises`. This raises a warning in our compatibility workflow e.g. [HERE](https://github.com/skypyproject/skypy/runs/6438716098?check_suite_focus=true#step:6:150). Following the astropy recommendation, this PR drops `astropy.tests.helper.raises` and uses `pytest.raises` instead.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
