### PR TITLE
BLD: Set numpy latest supported version to 1.23

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{37,38,39,310}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
-    py{37,38,39,310}-test-numpy{116,117,118,119,120,121,122}
+    py{37,38,39,310}-test-numpy{116,117,118,119,120,121,122,123}
     py{37,38,39,310}-test-scipy{12,13,14,15,16,17,18}
     py{37,38,39,310}-test-astropy{40,41,42,43,50,51}
     build_docs
@@ -45,6 +45,7 @@ description =
     numpy120: with numpy 1.20.*
     numpy121: with numpy 1.21.*
     numpy122: with numpy 1.22.*
+    numpy123: with numpy 1.23.*
     scipy12: with scipy 1.2.*
     scipy13: with scipy 1.3.*
     scipy14: with scipy 1.4.*
@@ -69,6 +70,7 @@ deps =
     numpy120: numpy==1.20.*
     numpy121: numpy==1.21.*
     numpy122: numpy==1.22.*
+    numpy123: numpy==1.23.*
 
     scipy12: scipy==1.2.*
     scipy13: scipy==1.3.*
@@ -90,7 +92,7 @@ deps =
     dev: git+https://github.com/astropy/astropy.git#egg=astropy
 
     latest: astropy==5.1.*
-    latest: numpy==1.22.*
+    latest: numpy==1.23.*
     latest: scipy==1.8.*
 
     oldest: astropy==4.0.*


### PR DESCRIPTION
## Description
Set numpy latest supported version to 1.23

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [ ] Assign someone from the infrastructure team to review this pull request
