### PR TITLE
[TST] Test CLASSY class, not classy function

### DIFF
--- a/skypy/power_spectrum/tests/test_class.py
+++ b/skypy/power_spectrum/tests/test_class.py
@@ -32,14 +32,14 @@ def test_classy():
     ps = CLASSY(k_max, redshift, Pl15massless)
     pzk = ps(wavenumber, redshift)
     assert pzk.shape == (len(redshift), len(wavenumber))
-    assert allclose(pzk, test_pzk, rtol=1.e-3)
+    assert allclose(pzk, test_pzk, rtol=1.e-4)
 
     # also check redshifts are ordered correctly
     redshift = [1.0, 0.0]
     ps = CLASSY(k_max, redshift, Pl15massless)
     pzk = ps(wavenumber, redshift)
     assert pzk.shape == (len(redshift), len(wavenumber))
-    assert allclose(pzk, test_pzk[np.argsort(redshift)], rtol=1.e-3)
+    assert allclose(pzk, test_pzk[np.argsort(redshift)], rtol=1.e-4)
 
     # also check scalar arguments are treated correctly
     redshift = 1.0


### PR DESCRIPTION
## Description
Merging will close #563 

This changes the test to be on the `CLASSY` class, rather than the to-be-deleted function.

## Checklist
- [X] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [X] Write unit tests
- [X] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [ ] Assign someone from the infrastructure team to review this pull request
