### PR TITLE
Test power spectra against "truth", both massless and massive nu

### DIFF
--- a/skypy/power_spectrum/_camb.py
+++ b/skypy/power_spectrum/_camb.py
@@ -14,7 +14,7 @@ class CAMB(TabulatedPowerSpectrum):
     redshift and wavenumber using CAMB.
     '''
 
-    def __init__(self, kmax, redshift, cosmology, A_s, n_s, **kwargs):
+    def __init__(self, kmax, redshift, cosmology, A_s, n_s, tau, **kwargs):
 
         try:
             from camb import CAMBparams, model, get_results
@@ -30,16 +30,25 @@ class CAMB(TabulatedPowerSpectrum):
                            omk=cosmology.Ok0,
                            TCMB=cosmology.Tcmb0.value,
                            mnu=np.sum(cosmology.m_nu.to_value(units.eV)),
-                           standard_neutrino_neff=cosmology.Neff
+                           num_massive_neutrinos=1,
+                           standard_neutrino_neff=cosmology.Neff,
+                           tau=tau,
+                           YHe=0.24,
                            )
 
         pars.InitPower.ns = n_s
         pars.InitPower.As = A_s
         pars.NonLinear = model.NonLinear_none
         k_per_logint, var1, var2, hubble_units, nonlinear = None, None, None, False, False
-        pars.set_matter_power(redshifts=redshift, kmax=kmax, k_per_logint=k_per_logint, silent=True)
+        pars.set_matter_power(redshifts=redshift,
+                              kmax=kmax,
+                              k_per_logint=k_per_logint,
+                              # accurate_massive_neutrino_transfers=True,
+                              silent=True)
+
         results = get_results(pars)
         k, z, p = results.get_linear_matter_power_spectrum(var1, var2, hubble_units,
+                                                           k_hunit=False,
                                                            nonlinear=nonlinear)
 
-        super().__init__(k*cosmology.h, z, p)
+        super().__init__(k, z, p)

--- a/skypy/power_spectrum/tests/test_class.py
+++ b/skypy/power_spectrum/tests/test_class.py
@@ -5,9 +5,15 @@ from astropy import units as u
 from astropy.utils.data import get_pkg_data_filename
 import pytest
 
+'''
+from matplotlib import pyplot as plt
+plt.ion()
+plt.loglog(test_k, np.abs(test_pzk[0]/pzk[0] - 1))
+'''
+
 # load the external class result to test against
-class_result_filename = get_pkg_data_filename('data/class_result.txt')
-test_pzk = np.loadtxt(class_result_filename)
+# class_result_filename = get_pkg_data_filename('data/class_result.txt')
+# test_pzk = np.loadtxt(class_result_filename)
 
 # try to import the requirement, if it doesn't exist, skip test
 try:
@@ -18,32 +24,77 @@ except ImportError:
 
 
 @pytest.mark.skipif(CLASS_294_NOT_FOUND, reason='classy v2.9.4 not found')
-def test_classy():
+def test_classy_massive():
     '''
     Test a default astropy cosmology
     '''
+
+    truth_pk_filename = get_pkg_data_filename('data/truth_pk_massive_nu.txt')
+    test_k, test_pzk0, test_pzk1 = np.loadtxt(truth_pk_filename, unpack=True)
+    test_pzk = np.column_stack([test_pzk0, test_pzk1]).T
+
     from skypy.power_spectrum import CLASSY
 
-    Pl15massless = Planck15.clone(name='Planck 15 massless neutrino', m_nu=[0., 0., 0.]*u.eV)
-
+    A_s, n_s, tau = 2.e-9, 0.965, 0.079
     redshift = [0.0, 1.0]
-    wavenumber = np.logspace(-4.0, np.log10(2.0), 200)
+    # wavenumber = np.logspace(-4.0, np.log10(2.0), 200)
+    wavenumber = test_k
     k_max = wavenumber.max()
-    ps = CLASSY(k_max, redshift, Pl15massless)
+    ps = CLASSY(k_max, redshift, Planck15, A_s, n_s, tau)
     pzk = ps(wavenumber, redshift)
     assert pzk.shape == (len(redshift), len(wavenumber))
-    assert allclose(pzk, test_pzk, rtol=1.e-4)
+    assert allclose(pzk, test_pzk, rtol=2.e-3)
 
     # also check redshifts are ordered correctly
     redshift = [1.0, 0.0]
-    ps = CLASSY(k_max, redshift, Pl15massless)
+    ps = CLASSY(k_max, redshift, Planck15, A_s, n_s, tau)
     pzk = ps(wavenumber, redshift)
     assert pzk.shape == (len(redshift), len(wavenumber))
-    assert allclose(pzk, test_pzk[np.argsort(redshift)], rtol=1.e-4)
+    assert allclose(pzk, test_pzk[np.argsort(redshift)], rtol=2.e-3)
 
     # also check scalar arguments are treated correctly
     redshift = 1.0
     wavenumber = 1.e-1
-    ps = CLASSY(k_max, redshift, Pl15massless)
+    ps = CLASSY(k_max, redshift, Planck15, A_s, n_s, tau)
+    pzk = ps(wavenumber, redshift)
+    assert np.isscalar(pzk)
+
+
+@pytest.mark.skipif(CLASS_294_NOT_FOUND, reason='classy v2.9.4 not found')
+def test_classy_massless():
+    '''
+    Test a default astropy cosmology
+    '''
+
+    truth_pk_filename = get_pkg_data_filename('data/truth_pk_massless_nu.txt')
+    test_k, test_pzk0, test_pzk1 = np.loadtxt(truth_pk_filename, unpack=True)
+    test_pzk = np.column_stack([test_pzk0, test_pzk1]).T
+
+    from skypy.power_spectrum import CLASSY
+
+    Planck15massless = Planck15.clone(name='Planck 15 massless neutrino',
+                                      m_nu=[0., 0., 0.]*u.eV)
+
+    A_s, n_s, tau = 2.e-9, 0.965, 0.079
+    redshift = [0.0, 1.0]
+    # wavenumber = np.logspace(-4.0, np.log10(2.0), 200)
+    wavenumber = test_k
+    k_max = wavenumber.max()
+    ps = CLASSY(k_max, redshift, Planck15massless, A_s, n_s, tau)
+    pzk = ps(wavenumber, redshift)
+    assert pzk.shape == (len(redshift), len(wavenumber))
+    assert allclose(pzk, test_pzk, rtol=2.e-3)
+
+    # also check redshifts are ordered correctly
+    redshift = [1.0, 0.0]
+    ps = CLASSY(k_max, redshift, Planck15massless, A_s, n_s, tau)
+    pzk = ps(wavenumber, redshift)
+    assert pzk.shape == (len(redshift), len(wavenumber))
+    assert allclose(pzk, test_pzk[np.argsort(redshift)], rtol=2.e-3)
+
+    # also check scalar arguments are treated correctly
+    redshift = 1.0
+    wavenumber = 1.e-1
+    ps = CLASSY(k_max, redshift, Planck15massless, A_s, n_s, tau)
     pzk = ps(wavenumber, redshift)
     assert np.isscalar(pzk)


### PR DESCRIPTION
## Description

This PR addresses #567 to improve power spectrum tests. I have made the following changes to the module:

- Added `tau` and `YHe` as parameters to fully specify base cosmology consistently between CLASS and CAMB. Note that currently only `tau` is accesible.
- Added ability to explicitly specify neutrino masses. Currently in CAMB it is assumed that all the mass is in one neutrino, whilst CLASS can also deal with e.g. degenerate masses. This can easily be changed to be the same for both.
- Clarified the Hubble units in the CAMB wrapper.

And implemented new / changed the tests such that both CLASS and CAMB are tested against a 'truth' cosmology which is calculated from CAMB, with separate tests for massive and massless neutrinos. We could do a lot of playing with accuracy settings here, both in terms of the rtol in the test and the accuracy settings within each Boltzmann code. Currently these are **_specified so that the tests pass with the default accuracy settings for each Boltzmann code_**. Thoughts welcome.

Merging will close #567.

## Checklist
- [X] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [X] Write unit tests
- [ ] Write documentation strings
- [X] Assign someone from your working team to review this pull request
- [X] Assign someone from the infrastructure team to review this pull request
