### PR TITLE
BUG: Overgeneration of galaxies

### DIFF
--- a/skypy/galaxies/redshift.py
+++ b/skypy/galaxies/redshift.py
@@ -126,7 +126,7 @@ def schechter_lf_redshift(redshift, M_star, phi_star, alpha, m_lim, sky_area,
         gam[i], _ = scipy.integrate.quad(f, lnxmin[i], np.inf, args=(alpha[i],))
 
     # comoving number density is normalisation times upper incomplete gamma
-    density = phi_star*gam
+    density = phi_star*gam*np.power(cosmology.h, 3)
 
     # sample redshifts from the comoving density
     return redshifts_from_comoving_density(redshift=redshift, density=density,


### PR DESCRIPTION
## Description
Added an h_0^3 to the number density calculated for galaxies and their redshifts. This closes #576 .

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [ ] Assign someone from the infrastructure team to review this pull request
