### PR TITLE
BUG: Overgeneration of galaxies

### DIFF
--- a/skypy/galaxies/redshift.py
+++ b/skypy/galaxies/redshift.py
@@ -126,7 +126,7 @@ def schechter_lf_redshift(redshift, M_star, phi_star, alpha, m_lim, sky_area,
         gam[i], _ = scipy.integrate.quad(f, lnxmin[i], np.inf, args=(alpha[i],))
 
     # comoving number density is normalisation times upper incomplete gamma
-    density = phi_star*gam
+    density = phi_star*gam*np.power(cosmology.h, 3)
 
     # sample redshifts from the comoving density
     return redshifts_from_comoving_density(redshift=redshift, density=density,

--- a/skypy/galaxies/tests/test_redshift.py
+++ b/skypy/galaxies/tests/test_redshift.py
@@ -32,7 +32,7 @@ def test_schechter_lf_redshift():
     x_min = 10.**(-0.4*(M_lim - M_star))
 
     # density with factor from upper incomplete gamma function
-    density = phi_star*gamma(alpha+1)*gammaincc(alpha+1, x_min)
+    density = phi_star*gamma(alpha+1)*gammaincc(alpha+1, x_min)*np.power(cosmo.h, 3)
 
     # turn into galaxies/surface area
     density *= (sky_area * cosmo.differential_comoving_volume(z)).to_value('Mpc3')


### PR DESCRIPTION
## Description
This fixes the overgeneration of galaxies caused by the lack of a $h_0^3$ factor in the number density calculation (required due to the units of $phi_*$. Attached are a PDF of a notebook showing this result and text files for the generation of the galaxies.
This will close #576 . 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [x] Write unit tests
- [ ] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [ ] Assign someone from the infrastructure team to review this pull request
[red_galaxy_text.txt](https://github.com/skypyproject/skypy/files/10031542/red_galaxy_text.txt)
[blue_galaxy_text.txt](https://github.com/skypyproject/skypy/files/10031543/blue_galaxy_text.txt)
[Galaxy_Overgeneration_(Git).pdf](https://github.com/skypyproject/skypy/files/10031544/Galaxy_Overgeneration_.Git.pdf)
