### PR TITLE
MAINT: Replaced whitespace in tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ indexserver =
 [testenv]
 
 # Pass through the following environment variables which may be needed for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
+passenv = HOME,WINDIR,LC_ALL,LC_CTYPE,CC,CI,TRAVIS
 
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree


### PR DESCRIPTION
Merging will close #586 

Tests currently fail because Tox v4 requires comma separation in passenv, rather than whitespace.
