### PR TITLE
BLD: Set astropy latest supported version to 5.2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{37,38,39,310}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
     py{37,38,39,310}-test-numpy{116,117,118,119,120,121,122,123}
     py{37,38,39,310}-test-scipy{12,13,14,15,16,17,18,19}
-    py{37,38,39,310}-test-astropy{40,41,42,43,50,51}
+    py{37,38,39,310}-test-astropy{40,41,42,43,50,51,52}
     build_docs
     linkcheck
     codestyle
@@ -60,6 +60,7 @@ description =
     astropy43: with astropy 4.3.*
     astropy50: with astropy 5.0.*
     astropy51: with astropy 5.1.*
+    astropy52: with astropy 5.2.*
 
 # The following provides some specific pinnings for key packages
 deps =
@@ -88,12 +89,13 @@ deps =
     astropy43: astropy==4.3.*
     astropy50: astropy==5.0.*
     astropy51: astropy==5.1.*
+    astropy52: astropy==5.2.*
 
     dev: :NIGHTLY:numpy
     dev: :NIGHTLY:scipy
     dev: git+https://github.com/astropy/astropy.git#egg=astropy
 
-    latest: astropy==5.1.*
+    latest: astropy==5.2.*
     latest: numpy==1.23.*
     latest: scipy==1.9.*
 


### PR DESCRIPTION
## Description
Set astropy latest supported version to 5.2

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
