### PR TITLE
Fix CI for module/halos; add six as a dependency and use ellipsis in growth doctests

### DIFF
--- a/docs/halos/examples/halos.yml
+++ b/docs/halos/examples/halos.yml
@@ -1,4 +1,4 @@
-cosmology: !astropy.cosmology.default_cosmology.get 
+cosmology: !astropy.cosmology.default_cosmology.get []
 power_spectrum: !skypy.power_spectrum.eisenstein_hu
   wavenumber: !numpy.logspace [-3, 1, 100]
   A_s: 2.1982e-09

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,10 +36,12 @@ all =
     h5py
     speclite>=0.14
     colossus
+    six
 docs =
     sphinx-astropy
     matplotlib
     colossus
+    six
     speclite>=0.14
 
 [options.package_data]

--- a/skypy/power_spectrum/_growth.py
+++ b/skypy/power_spectrum/_growth.py
@@ -99,7 +99,7 @@ def growth_factor(redshift, cosmology, gamma=6.0/11.0):
     >>> from astropy.cosmology import FlatLambdaCDM
     >>> cosmology = FlatLambdaCDM(H0=67.04, Om0=0.3183, Ob0=0.047745)
     >>> growth_factor(0, cosmology)
-    0.5355746155304598
+    0.535574...
 
     References
     ----------
@@ -148,7 +148,7 @@ def growth_function(redshift, cosmology, gamma=6.0/11.0, z_upper=1100):
     >>> from astropy.cosmology import FlatLambdaCDM
     >>> cosmology = FlatLambdaCDM(H0=67.04, Om0=0.3183, Ob0=0.047745)
     >>> growth_function(0, cosmology)
-    0.7909271056297236
+    0.790927...
 
     References
     ----------
@@ -218,7 +218,7 @@ def growth_function_derivative(redshift, cosmology, gamma=6.0/11.0):
     >>> from astropy.cosmology import FlatLambdaCDM
     >>> cosmology = FlatLambdaCDM(H0=67.04, Om0=0.3183, Ob0=0.047745)
     >>> growth_function_derivative(0, cosmology)
-    -0.42360048051025856
+    -0.423600...
 
     References
     ----------


### PR DESCRIPTION
## Description
Resolves two issues with unit tests in module/halos branch:
- `six` is required by colossus
- In docstring tests for growth use ellipsis instead of trailing decimal places

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
