### PR TITLE
tox indexserver is deprecated; use PIP_INDEX_URL and PIP_EXTRA_INDEX_URL in dev environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,6 @@ requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
 isolated_build = true
-indexserver =
-    NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 
 [testenv]
 
@@ -95,8 +93,8 @@ deps =
     astropy51: astropy==5.1.*
     astropy52: astropy==5.2.*
 
-    dev: :NIGHTLY:numpy
-    dev: :NIGHTLY:scipy
+    dev: numpy
+    dev: scipy
     dev: git+https://github.com/astropy/astropy.git#egg=astropy
 
     latest: astropy==5.2.*
@@ -120,6 +118,13 @@ commands =
     pip freeze
     !cov: pytest --pyargs skypy {toxinidir}/docs {posargs}
     cov: pytest --pyargs skypy {toxinidir}/docs --cov skypy --cov-config={toxinidir}/setup.cfg {posargs}
+
+# For dev environment, use scipy-nightly-wheels as the default index server (for numpy and scipy)
+# and PyPI as the extra index server (for all other dependencies, except astropy which is installed
+# directly from GitHub).
+setenv =
+    dev: PIP_INDEX_URL = https://pypi.anaconda.org/scipy-wheels-nightly/simple
+    dev: PIP_EXTRA_INDEX_URL = https://pypi.org/simple
 
 [testenv:build_docs]
 changedir = docs


### PR DESCRIPTION
## Description
The tox indexserver configuration has been removed. This is causing the compatibility workflow to fail for dev environments which attempt to install numpy and scipy from the scipy-nightly-wheels server. This pull request modifies the tox dev environments to instead set the PIP_INDEX_URL and PIP_EXTRA_INDEX_URL environment variables to scipy-nightly-wheels and PyPI respectively.

I have tested this on a branch where I modified the compatibility workflow to be run on git pushes (rather than a cron schedule):
- Failing before the fix: https://github.com/rrjbca/skypy/actions/runs/4525234641/jobs/7969595361
- Passing with the fix cherry-pick'd: https://github.com/rrjbca/skypy/actions/runs/4525238985/jobs/7969602066

(Note that the passing tests installed numpy==1.25.0.dev0+941.gb35aac2c3 and scipy==1.11.0.dev0 develop versions from scipy-nightly-wheels while all other dependencies are releases installed from PyPI as intended).

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
