### PR TITLE
BLD: Set numpy latest supported version to 1.25

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{37,38,39,310,311}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
-    py{37,38,39,310,311}-test-numpy{116,117,118,119,120,121,122,123,124}
+    py{37,38,39,310,311}-test-numpy{116,117,118,119,120,121,122,123,124,125}
     py{37,38,39,310,311}-test-scipy{12,13,14,15,16,17,18,19,110}
     py{37,38,39,310,311}-test-astropy{40,41,42,43,50,51,52}
     build_docs
@@ -45,6 +45,7 @@ description =
     numpy122: with numpy 1.22.*
     numpy123: with numpy 1.23.*
     numpy124: with numpy 1.24.*
+    numpy125: with numpy 1.25.*
     scipy12: with scipy 1.2.*
     scipy13: with scipy 1.3.*
     scipy14: with scipy 1.4.*
@@ -74,6 +75,7 @@ deps =
     numpy122: numpy==1.22.*
     numpy123: numpy==1.23.*
     numpy124: numpy==1.24.*
+    numpy125: numpy==1.25.*
 
     scipy12: scipy==1.2.*
     scipy13: scipy==1.3.*
@@ -98,7 +100,7 @@ deps =
     dev: git+https://github.com/astropy/astropy.git#egg=astropy
 
     latest: astropy==5.2.*
-    latest: numpy==1.24.*
+    latest: numpy==1.25.*
     latest: scipy==1.10.*
 
     oldest: astropy==4.0.*


### PR DESCRIPTION
## Description
Set numpy latest supported version to 1.25

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
