### PR TITLE
BLD: Set astropy latest supported version to 5.3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{37,38,39,310,311}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
     py{37,38,39,310,311}-test-numpy{116,117,118,119,120,121,122,123,124}
     py{37,38,39,310,311}-test-scipy{12,13,14,15,16,17,18,19,110}
-    py{37,38,39,310,311}-test-astropy{40,41,42,43,50,51,52}
+    py{37,38,39,310,311}-test-astropy{40,41,42,43,50,51,52,53}
     build_docs
     linkcheck
     codestyle
@@ -61,6 +61,7 @@ description =
     astropy50: with astropy 5.0.*
     astropy51: with astropy 5.1.*
     astropy52: with astropy 5.2.*
+    astropy53: with astropy 5.3.*
 
 # The following provides some specific pinnings for key packages
 deps =
@@ -92,12 +93,13 @@ deps =
     astropy50: astropy==5.0.*
     astropy51: astropy==5.1.*
     astropy52: astropy==5.2.*
+    astropy53: astropy==5.3.*
 
     dev: numpy
     dev: scipy
     dev: git+https://github.com/astropy/astropy.git#egg=astropy
 
-    latest: astropy==5.2.*
+    latest: astropy==5.3.*
     latest: numpy==1.24.*
     latest: scipy==1.10.*
 


### PR DESCRIPTION
## Description
Set astropy latest supported version to 5.3

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
