### PR TITLE
MAINT: Update _astropy_init to latest version in astropy package-template

### DIFF
--- a/skypy/_astropy_init.py
+++ b/skypy/_astropy_init.py
@@ -1,52 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import os
 
-__all__ = ['__version__']
-
-# this indicates whether or not we are in the package's setup.py
-try:
-    _ASTROPY_SETUP_
-except NameError:
-    import builtins
-    builtins._ASTROPY_SETUP_ = False
+__all__ = ['__version__', 'test']
 
 try:
     from .version import version as __version__
 except ImportError:
     __version__ = ''
 
-
-if not _ASTROPY_SETUP_:  # noqa
-    import os
-    from warnings import warn
-    from astropy.config.configuration import (
-        update_default_config,
-        ConfigurationDefaultMissingError,
-        ConfigurationDefaultMissingWarning)
-
-    # Create the test function for self test
-    from astropy.tests.runner import TestRunner
-    test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
-    test.__test__ = False
-    __all__ += ['test']
-
-    # add these here so we only need to cleanup the namespace at the end
-    config_dir = None
-
-    if not os.environ.get('ASTROPY_SKIP_CONFIG_UPDATE', False):
-        config_dir = os.path.dirname(__file__)
-        config_template = os.path.join(config_dir, __package__ + ".cfg")
-        if os.path.isfile(config_template):
-            try:
-                update_default_config(
-                    __package__, config_dir, version=__version__)
-            except TypeError as orig_error:
-                try:
-                    update_default_config(__package__, config_dir)
-                except ConfigurationDefaultMissingError as e:
-                    wmsg = (e.args[0] +
-                            " Cannot install default profile. If you are "
-                            "importing from source, this is expected.")
-                    warn(ConfigurationDefaultMissingWarning(wmsg))
-                    del e
-                except Exception:
-                    raise orig_error
+# Create the test function for self test
+from astropy.tests.runner import TestRunner
+test = TestRunner.make_test_runner_in(os.path.dirname(__file__))


### PR DESCRIPTION
## Description

The compatibility workflow is currently failing for the astropy development version with `ImportError: cannot import name 'update_default_config' from 'astropy.config.configuration'` : https://github.com/skypyproject/skypy/actions/runs/6681172883/job/18155043088#step:6:117

`update_default_config` was deprected in astropy 5.0 and was recently removed on the main branch in preparation for 6.0: https://github.com/astropy/astropy/pull/15466

This PR updates _astropy_init.py to match the latest version in astropy package-template which no longer requires `update_default_config`: https://github.com/astropy/package-template/blob/cookiecutter/%7B%7B%20cookiecutter.package_name%20%7D%7D/%7B%7B%20cookiecutter.module_name%20%7D%7D/_%7B%7B%20cookiecutter._parent_project%20%7D%7D_init.py

This patch has been demonstrated to resolve the issue on with the compatibility workflow here: https://github.com/rrjbca/skypy/actions/runs/6682165049/job/18157042681

Once approved I can also backport to v0.5.x and make a release v0.5.3 which will be necessary for the compatibility workflow "latest" job to pass.  

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
