### PR TITLE
MAINT: Update .readthedocs.yml to latest version in astropy package-template

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,13 +1,14 @@
 version: 2
 
 build:
-  image: latest
+  os: ubuntu-20.04
+  tools:
+    python: '3.7'
 
 sphinx:
   fail_on_warning: true
 
 python:
-  version: 3.7
   install:
     - method: pip
       path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,8 @@ build:
   os: ubuntu-20.04
   tools:
     python: '3.7'
+  apt_packages:
+    - graphviz
 
 sphinx:
   fail_on_warning: true

--- a/skypy/utils/photometry.py
+++ b/skypy/utils/photometry.py
@@ -436,7 +436,7 @@ def logistic_completeness_function(magnitude, magnitude_95, magnitude_50):
         is array_like of shape (nb, ) it returns array_like of shape (nb, ).
 
     References
-    -----------
+    ----------
     .. [1] López-Sanjuan, C. et al., `2017A&A…599A..62L`_
     .. _2017A&A…599A..62L: https://ui.adsabs.harvard.edu/abs/2017A%26A...599A..62L
 


### PR DESCRIPTION
## Description

Readthedocs is currently failing for #608 with `Problem in your project's configuration. Invalid configuration option "build.os": os not found`: https://readthedocs.org/projects/skypy/builds/22378505/

This PR updates .readthedocs.yml following the latest version in astropy package-template which configures the build os: https://github.com/astropy/package-template/blob/cookiecutter/%7B%7B%20cookiecutter.package_name%20%7D%7D/.readthedocs.yml

Also fixes two subsequent failures:

- Fixes incorrect underline length in the docstring for `logistic_completeness_function`
- Add graphviz to apt_packages in readthecods configuration

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
