### PR TITLE
BLD: Set astropy latest supported version to 6.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{37,38,39,310,311}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
     py{37,38,39,310,311}-test-numpy{116,117,118,119,120,121,122,123,124,125,126}
     py{37,38,39,310,311}-test-scipy{12,13,14,15,16,17,18,19,110,111,112,113}
-    py{37,38,39,310,311}-test-astropy{40,41,42,43,50,51,52,53,60}
+    py{37,38,39,310,311}-test-astropy{40,41,42,43,50,51,52,53,60,61}
     build_docs
     linkcheck
     codestyle
@@ -68,6 +68,7 @@ description =
     astropy52: with astropy 5.2.*
     astropy53: with astropy 5.3.*
     astropy60: with astropy 6.0.*
+    astropy61: with astropy 6.1.*
 
 # The following provides some specific pinnings for key packages
 deps =
@@ -106,12 +107,13 @@ deps =
     astropy52: astropy==5.2.*
     astropy53: astropy==5.3.*
     astropy60: astropy==6.0.*
+    astropy61: astropy==6.1.*
 
     dev: numpy
     dev: scipy
     dev: git+https://github.com/astropy/astropy.git#egg=astropy
 
-    latest: astropy==6.0.*
+    latest: astropy==6.1.*
     latest: numpy==1.26.*
     latest: scipy==1.13.*
 


### PR DESCRIPTION
## Description
Set astropy latest supported version to 6.1

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
