### PR TITLE
BUG: Use scipy.integrate.cumulative_trapezoid

### DIFF
--- a/skypy/galaxies/tests/test_stellar_mass.py
+++ b/skypy/galaxies/tests/test_stellar_mass.py
@@ -68,7 +68,7 @@ def test_stellar_masses():
         mass_min = 10 ** 7
         mass_max = 10 ** 13
         pdf = calc_pdf(m, alpha, mass_star, mass_min, mass_max)
-        cdf = scipy.integrate.cumtrapz(pdf, m, initial=0)
+        cdf = scipy.integrate.cumulative_trapezoid(pdf, m, initial=0)
         cdf = cdf / cdf[-1]
         return cdf
 

--- a/skypy/galaxies/tests/test_velocity_dispersion.py
+++ b/skypy/galaxies/tests/test_velocity_dispersion.py
@@ -1,7 +1,7 @@
 import numpy as np
 from scipy.stats import kstest
 from scipy.special import gamma
-from scipy.integrate import cumtrapz
+from scipy.integrate import cumulative_trapezoid
 
 
 def test_schechter_vdf():
@@ -30,7 +30,7 @@ def test_schechter_vdf():
 
     def calc_cdf(m):
         pdf = calc_pdf(m)
-        cdf = cumtrapz(pdf, m, initial=0)
+        cdf = cumulative_trapezoid(pdf, m, initial=0)
         cdf /= cdf[-1]
         return cdf
 


### PR DESCRIPTION
## Description
The alias `scipy.integrate.cumtrapz` is deprecated. Use `scipy.integrate.cumulative_trapezoid` instead.

Depends on #618 incrementing the minimum supported version of scipy to 1.6 (the version when `scipy.integrate.cumulative_trapezoid` was added)

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
