### PR TITLE
BLD: Set scipy oldest supported version to 1.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     py{37,38,39,310,311}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
     py{37,38,39,310,311}-test-numpy{116,117,118,119,120,121,122,123,124,125,126}
-    py{37,38,39,310,311}-test-scipy{12,13,14,15,16,17,18,19,110,111,112,113}
+    py{37,38,39,310,311}-test-scipy{16,17,18,19,110,111,112,113}
     py{37,38,39,310,311}-test-astropy{40,41,42,43,50,51,52,53,60,61}
     build_docs
     linkcheck
@@ -47,10 +47,6 @@ description =
     numpy124: with numpy 1.24.*
     numpy125: with numpy 1.25.*
     numpy125: with numpy 1.26.*
-    scipy12: with scipy 1.2.*
-    scipy13: with scipy 1.3.*
-    scipy14: with scipy 1.4.*
-    scipy15: with scipy 1.5.*
     scipy16: with scipy 1.6.*
     scipy17: with scipy 1.7.*
     scipy18: with scipy 1.8.*
@@ -85,10 +81,6 @@ deps =
     numpy125: numpy==1.25.*
     numpy125: numpy==1.26.*
 
-    scipy12: scipy==1.2.*
-    scipy13: scipy==1.3.*
-    scipy14: scipy==1.4.*
-    scipy15: scipy==1.5.*
     scipy16: scipy==1.6.*
     scipy17: scipy==1.7.*
     scipy18: scipy==1.8.*
@@ -119,7 +111,7 @@ deps =
 
     oldest: astropy==4.0.*
     oldest: numpy==1.16.*
-    oldest: scipy==1.2.*
+    oldest: scipy==1.6.*
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =


### PR DESCRIPTION
## Description
In scipy 1.14 the `scipy.integrate.cumtrapz` will be deprecated. However the alias `scipy.integrate.cumulative_trapezoid` was not added until scipy 1.6. This pull request increases the oldest supported version of scipy to 1.6.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
