### PR TITLE
BLD: Set numpy oldest supported version to 1.17

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{38,39,310,311,312}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
-    py{38,39,310,311,312}-test-numpy{116,117,118,119,120,121,122,123,124,125,126,20}
+    py{38,39,310,311,312}-test-numpy{117,118,119,120,121,122,123,124,125,126,20}
     py{38,39,310,311,312}-test-scipy{16,17,18,19,110,111,112,113,114}
     py{38,39,310,311,312}-test-astropy{40,41,42,43,50,51,52,53,60,61}
     build_docs
@@ -36,7 +36,6 @@ description =
     latest: with the latest supported version of key dependencies
     oldest: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy116: with numpy 1.16.*
     numpy117: with numpy 1.17.*
     numpy118: with numpy 1.18.*
     numpy119: with numpy 1.19.*
@@ -71,7 +70,6 @@ description =
 # The following provides some specific pinnings for key packages
 deps =
 
-    numpy116: numpy==1.16.*
     numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*
     numpy119: numpy==1.19.*
@@ -114,7 +112,7 @@ deps =
     latest: scipy==1.14.*
 
     oldest: astropy==4.0.*
-    oldest: numpy==1.16.*
+    oldest: numpy==1.17.*
     oldest: scipy==1.6.*
 
 # The following indicates which extras_require from setup.cfg will be installed


### PR DESCRIPTION
## Description
Set numpy oldest supported version to 1.17

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
