### PR TITLE
MAINT: scipy deprecation fixes for halos module (attempt 2)

### DIFF
--- a/skypy/halos/mass.py
+++ b/skypy/halos/mass.py
@@ -325,7 +325,7 @@ def _sigma_squared(M, k, Pk, growth_function, cosmology):
     top_hat = 3. * (np.sin(k * R) - k * R * np.cos(k * R)) / ((k * R)**3.)
     integrand = Pk * np.power(top_hat * k, 2)
 
-    return Dz2 * integrate.simps(integrand, k) / (2. * np.pi**2.)
+    return Dz2 * integrate.simpson(integrand, k) / (2. * np.pi**2.)
 
 
 def _dlns_dlnM(sigma, M):

--- a/skypy/halos/tests/test_quenching.py
+++ b/skypy/halos/tests/test_quenching.py
@@ -14,7 +14,7 @@ def test_environment_quenched():
     number_quenched = Counter(quenched)[True]
 
     p_value = stats.binomtest(number_quenched, n=n, p=p,
-                               alternative='two-sided')
+                               alternative='two-sided').pvalue
     assert p_value > 0.01
 
 
@@ -29,5 +29,5 @@ def test_mass_quenched():
     number_quenched = Counter(quenched)[True]
 
     p_value = stats.binomtest(number_quenched, n=n, p=0.5,
-                               alternative='two-sided')
+                               alternative='two-sided').pvalue
     assert p_value > 0.01

--- a/skypy/halos/tests/test_quenching.py
+++ b/skypy/halos/tests/test_quenching.py
@@ -13,7 +13,7 @@ def test_environment_quenched():
     quenched = environment_quenched(n, p)
     number_quenched = Counter(quenched)[True]
 
-    p_value = stats.binom_test(number_quenched, n=n, p=p,
+    p_value = stats.binomtest(number_quenched, n=n, p=p,
                                alternative='two-sided')
     assert p_value > 0.01
 
@@ -28,6 +28,6 @@ def test_mass_quenched():
     quenched = mass_quenched(halo_mass, offset, width)
     number_quenched = Counter(quenched)[True]
 
-    p_value = stats.binom_test(number_quenched, n=n, p=0.5,
+    p_value = stats.binomtest(number_quenched, n=n, p=0.5,
                                alternative='two-sided')
     assert p_value > 0.01

--- a/skypy/halos/tests/test_quenching.py
+++ b/skypy/halos/tests/test_quenching.py
@@ -14,7 +14,7 @@ def test_environment_quenched():
     number_quenched = Counter(quenched)[True]
 
     p_value = stats.binomtest(number_quenched, n=n, p=p,
-                               alternative='two-sided').pvalue
+                              alternative='two-sided').pvalue
     assert p_value > 0.01
 
 
@@ -29,5 +29,5 @@ def test_mass_quenched():
     number_quenched = Counter(quenched)[True]
 
     p_value = stats.binomtest(number_quenched, n=n, p=0.5,
-                               alternative='two-sided').pvalue
+                              alternative='two-sided').pvalue
     assert p_value > 0.01

--- a/skypy/power_spectrum/tests/test_growth.py
+++ b/skypy/power_spectrum/tests/test_growth.py
@@ -57,15 +57,15 @@ def test_growth():
     Dzprime = growth_function_derivative(redshift, cosmology_flat)
 
     # Test growth factor
-    assert redshift.shape == fz.shape,\
+    assert redshift.shape == fz.shape, \
         "Length of redshift array and growth rate array do not match"
-    assert isclose(fz[0], 1.0),\
+    assert isclose(fz[0], 1.0), \
         "Growth factor at redshift 0 is not close to 1.0"
 
     # Test growth function
-    assert redshift.shape == Dz.shape,\
+    assert redshift.shape == Dz.shape, \
         "Length of redshift array and growth function array do not match"
-    assert allclose(Dz, 1. / (1. + redshift)),\
+    assert allclose(Dz, 1. / (1. + redshift)), \
         "Growth function is not close to the scale factor"
 
     # make sure that growth_function with scalar returns scalar
@@ -74,9 +74,9 @@ def test_growth():
     assert Dz2 == Dz[2], 'growth function with scalar produced inconsistent result'
 
     # Test growth function derivative
-    assert redshift.shape == Dzprime.shape,\
+    assert redshift.shape == Dzprime.shape, \
         "Length of redshift array and growth function array do not match"
-    assert isclose(Dzprime[0], -1.0),\
+    assert isclose(Dzprime[0], -1.0), \
         "Derivative of growth function at redshift 0 is not close to -1.0"
 
     # Test against precomputed values using Planck15 cosmology


### PR DESCRIPTION
## Description

Re-PR of #631 but not using the `modules/` name so as not to have branch protection on the source PR.
