### PR TITLE
BLD: Set astropy latest supported version to 7.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{38,39,310,311,312}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
     py{38,39,310,311,312}-test-numpy{117,118,119,120,121,122,123,124,125,126,20,21}
     py{38,39,310,311,312}-test-scipy{16,17,18,19,110,111,112,113,114}
-    py{38,39,310,311,312}-test-astropy{40,41,42,43,50,51,52,53,60,61}
+    py{38,39,310,311,312}-test-astropy{40,41,42,43,50,51,52,53,60,61,70}
     build_docs
     linkcheck
     codestyle
@@ -67,6 +67,7 @@ description =
     astropy53: with astropy 5.3.*
     astropy60: with astropy 6.0.*
     astropy61: with astropy 6.1.*
+    astropy70: with astropy 7.0.*
 
 # The following provides some specific pinnings for key packages
 deps =
@@ -104,12 +105,13 @@ deps =
     astropy53: astropy==5.3.*
     astropy60: astropy==6.0.*
     astropy61: astropy==6.1.*
+    astropy70: astropy==7.0.*
 
     dev: numpy
     dev: scipy
     dev: git+https://github.com/astropy/astropy.git#egg=astropy
 
-    latest: astropy==6.1.*
+    latest: astropy==7.0.*
     latest: numpy==2.1.*
     latest: scipy==1.14.*
 


### PR DESCRIPTION
## Description
Set astropy latest supported version to 7.0

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
