### PR TITLE
MAINT: Don't use importlib.resources.files as a context manager

### DIFF
--- a/skypy/galaxies/spectrum.py
+++ b/skypy/galaxies/spectrum.py
@@ -107,15 +107,15 @@ class KCorrectTemplates(SpectrumTemplates):
     '''
 
     def __init__(self, hdu=1):
-        with resources.files('skypy') / 'data/kcorrect/k_nmf_derived.default.fits' as filename:
-            with fits.open(filename) as hdul:
-                self.templates = hdul[hdu].data * units.Unit('erg s-1 cm-2 angstrom-1')
-                self.wavelength = hdul[11].data * units.Unit('angstrom')
-                self.mass = hdul[16].data
-                self.mremain = hdul[17].data
-                self.mets = hdul[18].data
-                self.mass300 = hdul[19].data
-                self.mass1000 = hdul[20].data
+        filename = resources.files('skypy') / 'data/kcorrect/k_nmf_derived.default.fits'
+        with fits.open(filename) as hdul:
+            self.templates = hdul[hdu].data * units.Unit('erg s-1 cm-2 angstrom-1')
+            self.wavelength = hdul[11].data * units.Unit('angstrom')
+            self.mass = hdul[16].data
+            self.mremain = hdul[17].data
+            self.mets = hdul[18].data
+            self.mass300 = hdul[19].data
+            self.mass1000 = hdul[20].data
 
     def stellar_mass(self, coefficients, magnitudes, filter):
         r'''Compute stellar mass from absolute magnitudes in a reference filter.


### PR DESCRIPTION
## Description

In Python 3.13 the use of PosixPath objects as context managers is deprecated. Update the use of importlib.resources.files, storing the output to a variable instead. 

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
