### PR TITLE
BLD: Use python 3.13 with readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: '3.9'
+    python: '3.13'
   apt_packages:
     - graphviz
 


### PR DESCRIPTION
## Description

Use the latest supported version of python (3.13) when building documentation with readthedocs

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
