### PR TITLE
MAINT: Add required sphinx.configuration to readthedocs.conf

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,7 @@ build:
     - graphviz
 
 sphinx:
+  configuration: docs/conf.py
   fail_on_warning: true
 
 python:


### PR DESCRIPTION
## Description
Add explicit sphinx.configuration field which is now required in readthedoc.conf

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
