### PR TITLE
MAINT: Utility function to check if a value is a pole of the gamma function

### DIFF
--- a/skypy/utils/tests/test_special.py
+++ b/skypy/utils/tests/test_special.py
@@ -3,7 +3,7 @@ import numpy.testing as npt
 from astropy.utils.data import get_pkg_data_filename
 import pytest
 
-from skypy.utils.special import gammaincc
+from skypy.utils.special import gammaincc, _is_gamma_pole
 
 
 def test_gammaincc_scalar():
@@ -90,3 +90,25 @@ def test_gammaincc_neg_x_array():
     # negative x in array raises an exception
     with pytest.raises(ValueError):
         gammaincc(0.5, [3.0, 2.0, 1.0, 0.0, -1.0])
+
+
+gamma_poles = np.array([-2.0, -1.0, 0.0])
+not_gamma_poles = np.array([-2.5, 0.5, 1.0])
+
+
+@pytest.mark.parametrize('z', gamma_poles)
+def test_is_gamma_pole_scalar(z):
+    assert _is_gamma_pole(z)
+
+
+def test_is_gamma_pole_array():
+    assert np.all(_is_gamma_pole(gamma_poles))
+
+
+@pytest.mark.parametrize('z', not_gamma_poles)
+def test_is_not_gamma_pole_scalar(z):
+    assert not _is_gamma_pole(z)
+
+
+def test_is_not_gamma_pole_array():
+    assert not np.any(_is_gamma_pole(not_gamma_poles))


### PR DESCRIPTION
## Description

The SkyPy implementation of the upper incomplete gamma function uses `scipy.special.gammasgn` to identify poles of the gamma function. However since SciPy 1.15 the behaviour of that function has changed :

```python
# SciPy 1.14.1
>>> scipy.special.gammasgn([-2, -1, 0])
array([0., 0., 0.])

# SciPy 1.15.0
>>> scipy.special.gammasgn([-2, -1, 0])
array([nan, nan,  1.])
```

This MR introduces a utility function `_is_gamma_pole` that correctly identifies poles of the gamma function using `gammasgn` for all supported versions of SciPy

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [x] Write unit tests
- [x] Write documentation strings
- [x] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
