### PR TITLE
MAINT: astropy.cosmology.core is deprecated; import from astropy.cosm…

### DIFF
--- a/skypy/pipeline/tests/test_config.py
+++ b/skypy/pipeline/tests/test_config.py
@@ -3,7 +3,7 @@ import pytest
 from skypy.pipeline import load_skypy_yaml
 from skypy.pipeline._items import Call
 from astropy import units
-from astropy.cosmology.core import Cosmology
+from astropy.cosmology import Cosmology
 
 
 def test_load_skypy_yaml():

--- a/skypy/pipeline/tests/test_pipeline.py
+++ b/skypy/pipeline/tests/test_pipeline.py
@@ -1,5 +1,4 @@
-from astropy.cosmology import FlatLambdaCDM, default_cosmology
-from astropy.cosmology.core import Cosmology
+from astropy.cosmology import Cosmology, FlatLambdaCDM, default_cosmology
 from astropy.io import fits
 from astropy.io.misc.hdf5 import read_table_hdf5
 from astropy.table import Table, vstack


### PR DESCRIPTION
## Description

`astropy.cosmology.core` is [deprecated](https://docs.astropy.org/en/latest/changelog.html#id1400); import from `astropy.cosmology` instead

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
