### PR TITLE
BLD: Set astropy oldest supported version to 4.3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{39,310,311,312,313}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
     py{39,310,311,312,313}-test-numpy{119,120,121,122,123,124,125,126,20,21,22}
     py{39,310,311,312,313}-test-scipy{16,17,18,19,110,111,112,113,114,115}
-    py{39,310,311,312,313}-test-astropy{40,41,42,43,50,51,52,53,60,61,70}
+    py{39,310,311,312,313}-test-astropy{43,50,51,52,53,60,61,70}
     build_docs
     linkcheck
     codestyle
@@ -57,9 +57,6 @@ description =
     scipy113: with scipy 1.13.*
     scipy114: with scipy 1.14.*
     scipy114: with scipy 1.15.*
-    astropy40: with astropy 4.0.*
-    astropy41: with astropy 4.1.*
-    astropy42: with astropy 4.2.*
     astropy43: with astropy 4.3.*
     astropy50: with astropy 5.0.*
     astropy51: with astropy 5.1.*
@@ -95,9 +92,6 @@ deps =
     scipy114: scipy==1.14.*
     scipy114: scipy==1.15.*
 
-    astropy40: astropy==4.0.*
-    astropy41: astropy==4.1.*
-    astropy42: astropy==4.2.*
     astropy43: astropy==4.3.*
     astropy50: astropy==5.0.*
     astropy51: astropy==5.1.*
@@ -115,7 +109,7 @@ deps =
     latest: numpy==2.2.*
     latest: scipy==1.15.*
 
-    oldest: astropy==4.0.*
+    oldest: astropy==4.3.*
     oldest: numpy==1.19.*
     oldest: scipy==1.6.*
 


### PR DESCRIPTION
## Description
Recent change to import `Cosmology` from `astropy.cosmology` (in favour of soon-to-be-deprecated `astropy.cosmology.core.Cosmology`) is only backwards compatible as far as astropy 4.3. Older versions have been out of support for more than three years. This PR updates the oldest supported version of astropy to 4.3.

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
