### PR TITLE
MAINT: drop astropy TestRunner (deprecated)

### DIFF
--- a/skypy/_astropy_init.py
+++ b/skypy/_astropy_init.py
@@ -1,13 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
 
-__all__ = ['__version__', 'test']
+__all__ = ['__version__']
 
 try:
     from .version import version as __version__
 except ImportError:
     __version__ = ''
-
-# Create the test function for self test
-from astropy.tests.runner import TestRunner
-test = TestRunner.make_test_runner_in(os.path.dirname(__file__))

--- a/skypy/_astropy_init.py
+++ b/skypy/_astropy_init.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import os
 
 __all__ = ['__version__']
 


### PR DESCRIPTION
## Description

Drop astropy TestRunner as it will soon be deprecated

Resolves #648

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
