### PR TITLE
BLD: Set astropy latest supported version to 7.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{39,310,311,312,313}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
     py{39,310,311,312,313}-test-numpy{119,120,121,122,123,124,125,126,20,21,22}
     py{39,310,311,312,313}-test-scipy{16,17,18,19,110,111,112,113,114,115}
-    py{39,310,311,312,313}-test-astropy{43,50,51,52,53,60,61,70}
+    py{39,310,311,312,313}-test-astropy{43,50,51,52,53,60,61,70,71}
     build_docs
     linkcheck
     codestyle
@@ -65,6 +65,7 @@ description =
     astropy60: with astropy 6.0.*
     astropy61: with astropy 6.1.*
     astropy70: with astropy 7.0.*
+    astropy71 with astropy 7.1.*
 
 # The following provides some specific pinnings for key packages
 deps =
@@ -100,12 +101,13 @@ deps =
     astropy60: astropy==6.0.*
     astropy61: astropy==6.1.*
     astropy70: astropy==7.0.*
+    astropy71: astropy==7.1.*
 
     dev: numpy
     dev: scipy
     dev: git+https://github.com/astropy/astropy.git#egg=astropy
 
-    latest: astropy==7.0.*
+    latest: astropy==7.1.*
     latest: numpy==2.2.*
     latest: scipy==1.15.*
 


### PR DESCRIPTION
## Description

Set astropy latest supported version to 7.1

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
