### PR TITLE
BLD: Set numpy latest supported version to 2.3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{39,310,311,312,313}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
-    py{39,310,311,312,313}-test-numpy{119,120,121,122,123,124,125,126,20,21,22}
+    py{39,310,311,312,313}-test-numpy{119,120,121,122,123,124,125,126,20,21,22,23}
     py{39,310,311,312,313}-test-scipy{16,17,18,19,110,111,112,113,114,115}
     py{39,310,311,312,313}-test-astropy{43,50,51,52,53,60,61,70,71}
     build_docs
@@ -47,6 +47,7 @@ description =
     numpy20: with numpy 2.0.*
     numpy21: with numpy 2.1.*
     numpy22: with numpy 2.2.*
+    numpy23: with numpy 2.3.*
     scipy16: with scipy 1.6.*
     scipy17: with scipy 1.7.*
     scipy18: with scipy 1.8.*
@@ -81,6 +82,7 @@ deps =
     numpy20: numpy==2.0.*
     numpy21: numpy==2.1.*
     numpy22: numpy==2.2.*
+    numpy23: numpy==2.3.*
 
     scipy16: scipy==1.6.*
     scipy17: scipy==1.7.*
@@ -108,7 +110,7 @@ deps =
     dev: git+https://github.com/astropy/astropy.git#egg=astropy
 
     latest: astropy==7.1.*
-    latest: numpy==2.2.*
+    latest: numpy==2.3.*
     latest: scipy==1.15.*
 
     oldest: astropy==4.3.*


### PR DESCRIPTION
## Description

Set numpy latest supported version to 2.3

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
