### PR TITLE
BLD: Set astropy latest supported version to 8.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     py{310,311,312,313,314}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
     py{310,311,312,313,314}-test-numpy{121,122,123,124,125,126,20,21,22,23,24}
     py{310,311,312,313,314}-test-scipy{18,19,110,111,112,113,114,115,116,117}
-    py{310,311,312,313,314}-test-astropy{50,51,52,53,60,61,70,71,72}
+    py{310,311,312,313,314}-test-astropy{50,51,52,53,60,61,70,71,72,80}
     build_docs
     linkcheck
     codestyle
@@ -66,6 +66,7 @@ description =
     astropy70: with astropy 7.0.*
     astropy71 with astropy 7.1.*
     astropy72 with astropy 7.2.*
+    astropy80 with astropy 8.0.*
 
 # The following provides some specific pinnings for key packages
 deps =
@@ -102,12 +103,13 @@ deps =
     astropy70: astropy==7.0.*
     astropy71: astropy==7.1.*
     astropy72: astropy==7.2.*
+    astropy80: astropy==8.0.*
 
     dev: numpy
     dev: scipy
     dev: git+https://github.com/astropy/astropy.git#egg=astropy
 
-    latest: astropy==7.2.*
+    latest: astropy==8.0.*
     latest: numpy==2.4.*
     latest: scipy==1.17.*
 


### PR DESCRIPTION
## Description
Set astropy latest supported version to 8.0

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
