### PR TITLE
BLD: Set numpy latest supported version to 2.5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{310,311,312,313,314}-test{,-all}{,-dev,-latest,-oldest}{,-cov}
-    py{310,311,312,313,314}-test-numpy{121,122,123,124,125,126,20,21,22,23,24}
+    py{310,311,312,313,314}-test-numpy{121,122,123,124,125,126,20,21,22,23,24,25}
     py{310,311,312,313,314}-test-scipy{18,19,110,111,112,113,114,115,116,117,118}
     py{310,311,312,313,314}-test-astropy{50,51,52,53,60,61,70,71,72,80}
     build_docs
@@ -47,6 +47,7 @@ description =
     numpy22: with numpy 2.2.*
     numpy23: with numpy 2.3.*
     numpy24: with numpy 2.4.*
+    numpy25: with numpy 2.5.*
     scipy18: with scipy 1.8.*
     scipy19: with scipy 1.9.*
     scipy110: with scipy 1.10.*
@@ -83,6 +84,7 @@ deps =
     numpy22: numpy==2.2.*
     numpy23: numpy==2.3.*
     numpy24: numpy==2.4.*
+    numpy25: numpy==2.5.*
 
     scipy18: scipy==1.8.*
     scipy19: scipy==1.9.*
@@ -112,7 +114,7 @@ deps =
     dev: git+https://github.com/astropy/astropy.git#egg=astropy
 
     latest: astropy==8.0.*
-    latest: numpy==2.4.*
+    latest: numpy==2.5.*
     latest: scipy==1.18.*
 
     oldest: astropy==5.0.*


### PR DESCRIPTION
## Description
Set numpy latest supported version to 2.5

## Checklist
- [x] Follow the [Contributor Guidelines](https://github.com/skypyproject/skypy/blob/main/CONTRIBUTING.rst)
- [ ] Write unit tests
- [ ] Write documentation strings
- [ ] Assign someone from your working team to review this pull request
- [x] Assign someone from the infrastructure team to review this pull request
